### PR TITLE
perf(TokenMatcher): close the gap to java.util.regex

### DIFF
--- a/.github/workflows/test-compilation-benchmark.yml
+++ b/.github/workflows/test-compilation-benchmark.yml
@@ -55,7 +55,7 @@ jobs:
             (
               cd "$dir"
           
-              hyperfine --runs 5 --prepare "./mill clean && ./mill compile" "./mill test.compile" --export-json "../${dir}.json"
+              hyperfine --runs 5 --prepare "./mill clean && ./mill __.compile" "./mill __.test.compile" --export-json "../${dir}.json"
             )
             echo "::endgroup::"
           }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,23 +38,23 @@ jobs:
             ${{ runner.os }}-mill-
 
       - name: Compile
-        run: ./mill compile
+        run: ./mill __.compile
 
       - name: Compile tests
         run: |
           echo "Starting test compilation..."
           START_TIME=$(date +%s)
-          ./mill test.compile
+          ./mill __.test.compile
           END_TIME=$(date +%s)
           DURATION=$((END_TIME - START_TIME))
           echo "Test compilation completed in ${DURATION}s"
           echo "TEST_COMPILE_TIME=${DURATION}" >> $GITHUB_ENV
 
       - name: Run tests
-        run: ./mill test
+        run: ./mill __.test
 
       - name: Code coverage
-        run: ./mill scoverage.xmlCoberturaReport
+        run: ./mill jvm.scoverage.xmlCoberturaReport
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6
@@ -66,7 +66,7 @@ jobs:
         run: ./mill mill.scalalib.scalafmt/checkFormatAll
 
       - name: Generate Docs
-        run: ./mill docJar
+        run: ./mill jvm.docJar
 
       - name: Report Test Compilation Time
         if: always()

--- a/benchmarks/alpaca/src/RegexMatcherBenchmark.scala
+++ b/benchmarks/alpaca/src/RegexMatcherBenchmark.scala
@@ -1,0 +1,84 @@
+package alpaca.internal.lexer.regex
+
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+import java.util.regex.Pattern
+import scala.compiletime.uninitialized
+
+/**
+ * Compares the JDK `java.util.regex.Pattern` matcher (used by the lexer before
+ * the Native milestone) against the internal Brzozowski-derivative [[TokenMatcher]].
+ *
+ * Models the lexer's tokenization hot loop: at each position, find the longest
+ * prefix that matches one of the alternation branches; on no match, skip one char.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(1)
+class RegexMatcherBenchmark:
+
+  private val patterns = List(
+    " ",
+    "\\t",
+    "[a-zA-Z_][a-zA-Z0-9_]*",
+    "\\+",
+    "-",
+    "\\*",
+    "/",
+    "=",
+    ",",
+    "\\(",
+    "\\)",
+    "\\d+",
+    "#.*",
+    "\n+",
+  )
+
+  @Param(Array("100", "1000", "10000"))
+  var inputSize: Int = uninitialized
+
+  private var input: String = uninitialized
+  private var javaPattern: Pattern = uninitialized
+  private var matcher: TokenMatcher = uninitialized
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    val combined = patterns.zipWithIndex.map((p, i) => s"(?<g$i>$p)").mkString("|")
+    javaPattern = Pattern.compile(combined)
+    val regexes = patterns.map: p =>
+      RegexParser.parse(p) match
+        case Right(r) => r
+        case Left(err) => sys.error(s"parse failed for /$p/: $err")
+    matcher = TokenMatcher.fromRegexes(regexes*)
+
+    val sample = "foo = bar + 42 * (x - y) / z\n"
+    val builder = new StringBuilder(inputSize + sample.length)
+    while builder.length < inputSize do builder.append(sample)
+    input = builder.substring(0, inputSize)
+
+  @Benchmark
+  def javaRegex(bh: Blackhole): Unit =
+    val m = javaPattern.matcher(input)
+    var pos = 0
+    while pos < input.length do
+      m.region(pos, input.length)
+      if m.lookingAt() then
+        val end = m.end()
+        bh.consume(end)
+        pos = if end > pos then end else pos + 1
+      else pos += 1
+
+  @Benchmark
+  def tokenMatcher(bh: Blackhole): Unit =
+    var pos = 0
+    while pos < input.length do
+      matcher.matchAt(input, pos) match
+        case Some((_, end)) if end > pos =>
+          bh.consume(end)
+          pos = end
+        case _ => pos += 1

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.1.6
+//| mill-version: 1.1.5
 //| mill-jvm-version: 21
 //| mvnDeps:
 //| - com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION
@@ -10,90 +10,94 @@ package build
 import mill.*
 import mill.scalalib.*
 import mill.scalalib.publish.*
+import mill.scalanativelib.*
 import mill.contrib.scoverage.ScoverageModule
 import mill.contrib.jmh.JmhModule
 import mill.util.VcsVersion
 
-object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPublishModule:
-  def scalaVersion = "3.8.3-RC1"
+object `package` extends Module:
 
-  def scoverageVersion = "2.5.2"
+  trait Shared extends ScalaModule with PlatformScalaModule with SonatypeCentralPublishModule:
+    def scalaVersion = "3.8.3-RC1"
 
-  override def scalacOptions = Seq(
-    "-deprecation",
-    "-feature",
-    // "-explain",
-    "-new-syntax",
-    "-unchecked",
-    "-language:noAutoTupling",
-    "-Vprofile",
-    "-Xprint-inline",
-    // "-Ycheck:all", // cannot be enabled when scoverage used :/
-    "-Ycheck:macros",
-    // "-Ydebug-error",
-    "-Ydebug-flags",
-    "-Ydebug-missing-refs",
-    "-Yexplain-lowlevel",
-    "-Yexplicit-nulls",
-    // "-Yprint-debug",
-    // "-Xprint:postInlining",
-    // "-Xprint-suspension",
-    // "-Vprint:typer",
-    "-Wsafe-init",
-    "-Yshow-suppressed-errors",
-    "-Yshow-var-bounds",
-    "-Werror",
-    "-Wunused:all",
-    "-experimental",
-    "-preview",
-    s"-Xmacro-settings:debugDirectory=$moduleDir/debug,enableVerboseNames=true",
-    // "-Xmacro-settings:trace=file",
-    //  "-Yprofile-enabled",
-    //  s"-Yprofile-trace:$moduleDir/debug/compile-trace.json",
-  )
-
-  override def scalaDocOptions = Task {
-    Seq(
-      "-project",
-      "alpaca",
-      "-project-version",
-      publishVersion(),
-      "-project-logo",
-      s"$moduleDir/docs/_assets/images/logo.png",
-      "-project-footer",
-      "made with ❤️ and coffee",
-      "-social-links:github::https://github.com/halotukozak/alpaca",
-      "-snippet-compiler:compile",
-      s"-source-links:$moduleDir=github://halotukozak/alpaca/master",
-      "-revision:master",
+    override def scalacOptions = Seq(
+      "-deprecation",
+      "-feature",
+      // "-explain",
+      "-new-syntax",
+      "-unchecked",
+      "-language:noAutoTupling",
+      "-Vprofile",
+      "-Xprint-inline",
+      // "-Ycheck:all", // cannot be enabled when scoverage used :/
+      "-Ycheck:macros",
+      // "-Ydebug-error",
+      "-Ydebug-flags",
+      "-Ydebug-missing-refs",
+      "-Yexplain-lowlevel",
+      "-Yexplicit-nulls",
+      // "-Yprint-debug",
+      // "-Xprint:postInlining",
+      // "-Xprint-suspension",
+      // "-Vprint:typer",
+      "-Wsafe-init",
+      "-Yshow-suppressed-errors",
+      "-Yshow-var-bounds",
+      "-Werror",
+      "-Wunused:all",
+      "-experimental",
+      "-preview",
+      s"-Xmacro-settings:debugDirectory=$moduleDir/debug,enableVerboseNames=true",
+      // "-Xmacro-settings:trace=file",
+      //  "-Yprofile-enabled",
+      //  s"-Yprofile-trace:$moduleDir/debug/compile-trace.json",
     )
-  }
 
-  def artifactName = "alpaca"
+    override def scalaDocOptions = Task {
+      Seq(
+        "-project",
+        "alpaca",
+        "-project-version",
+        publishVersion(),
+        "-project-logo",
+        s"$moduleDir/docs/_assets/images/logo.png",
+        "-project-footer",
+        "made with ❤️ and coffee",
+        "-social-links:github::https://github.com/halotukozak/alpaca",
+        "-snippet-compiler:compile",
+        s"-source-links:$moduleDir=github://halotukozak/alpaca/master",
+        "-revision:master",
+      )
+    }
 
-  def publishVersion = Task(VcsVersion.vcsState().format())
+    def artifactName = "alpaca"
 
-  def pomSettings = PomSettings(
-    description = "Another Lexer Parser And Compiler Alpaca",
-    organization = "io.github.halotukozak",
-    url = "https://halotukozak.github.io/alpaca/docs/index.html",
-    licenses = Seq(License.MIT),
-    versionControl = VersionControl.github("halotukozak", "alpaca"),
-    developers = Seq(
-      Developer("halotukozak", "Bartłomiej Kozak", "https://github.com/halotukozak"),
-      Developer("Corvette653", "Bartosz Buczek", "https://github.com/Corvette653"),
-    ),
-  )
+    def publishVersion = Task(VcsVersion.vcsState().format())
 
-  def mvnDeps = Seq(
-    mvn"com.github.marianobarrios:dregex:0.9.0",
-    mvn"org.jparsec:jparsec:3.1",
-    mvn"org.slf4j:slf4j-api:2.0.17",
-    mvn"org.slf4j:slf4j-simple:2.0.17",
-  )
+    def pomSettings = PomSettings(
+      description = "Another Lexer Parser And Compiler Alpaca",
+      organization = "io.github.halotukozak",
+      url = "https://halotukozak.github.io/alpaca/docs/index.html",
+      licenses = Seq(License.MIT),
+      versionControl = VersionControl.github("halotukozak", "alpaca"),
+      developers = Seq(
+        Developer("halotukozak", "Bartłomiej Kozak", "https://github.com/halotukozak"),
+        Developer("Corvette653", "Bartosz Buczek", "https://github.com/Corvette653"),
+      ),
+    )
 
-  object test extends ScalaTests with TestModule.ScalaTest with ScoverageTests:
-    def scalaTestVersion = "3.2.19"
+  object jvm extends Shared with ScoverageModule:
+
+    def scoverageVersion = "2.5.2"
+
+    object test extends ScalaTests with TestModule.ScalaTest with ScoverageTests:
+      def scalaTestVersion = "3.2.19"
+
+  object native extends Shared with ScalaNativeModule:
+    def scalaNativeVersion = "0.5.10"
+
+    object test extends ScalaTests with TestModule.ScalaTest with ScalaNativeTests:
+      def scalaTestVersion = "3.2.19"
 
   object benchmarks extends Module:
 
@@ -103,9 +107,9 @@ object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPu
       override def forkWorkingDir = Task(moduleDir / os.up)
 
     object alpaca extends BenchmarkScalaModule with JmhModule:
-      def scalaVersion = build.scalaVersion()
+      def scalaVersion = build.jvm.scalaVersion()
       override def scalacOptions = Seq("-experimental", "-preview", "-Yretain-trees")
-      def moduleDeps = Seq(build)
+      def moduleDeps = Seq(build.jvm)
 
     object fastparse extends BenchmarkScalaModule:
       def scalaVersion = "3.8.3"

--- a/src/alpaca/internal/lexer/CompileNameAndPattern.scala
+++ b/src/alpaca/internal/lexer/CompileNameAndPattern.scala
@@ -2,6 +2,8 @@ package alpaca
 package internal
 package lexer
 
+import alpaca.internal.lexer.regex.{Regex, RegexParseError, RegexParser}
+
 import scala.annotation.tailrec
 
 /**
@@ -67,8 +69,19 @@ private[lexer] final class CompileNameAndPattern[Q <: Quotes](using val quotes: 
           logger.trace(show"matched named token with name=$str and alternatives ${alternatives.mkShow}")
           val patterns = alternatives.unsafeMap:
             case Literal(StringConstant(str)) => str
-          RegexChecker.checkPatterns(patterns)
-          RegexChecker.checkPatterns(patterns.reverse)
+          val items: List[(name: String, regex: Regex)] = patterns.map: p =>
+            RegexParser.parse(p) match
+              case Right(r) => (name = p, regex = r)
+              case Left(err: RegexParseError.UnsupportedFeature) =>
+                quotes.reflect.report.errorAndAbort(
+                  show"Unsupported regex feature `${err.feature}` at position ${err.position.toString} in pattern \"$p\"",
+                )
+              case Left(err: RegexParseError.InvalidSyntax) =>
+                quotes.reflect.report.errorAndAbort(
+                  show"Invalid regex pattern \"$p\" at position ${err.position.toString}: ${err.message}",
+                )
+          RegexChecker.checkRegexes(items)
+          RegexChecker.checkRegexes(items.reverse)
           TokenInfo(str, patterns.mkShow("|")) :: Nil
         case x => raiseShouldNeverBeCalled[List[(Type[? <: ValidName], TokenInfo)]](x.toString)
 

--- a/src/alpaca/internal/lexer/Lexer.scala
+++ b/src/alpaca/internal/lexer/Lexer.scala
@@ -3,8 +3,8 @@ package internal
 package lexer
 
 import alpaca.Token as TokenDef
+import alpaca.internal.lexer.regex.{Regex, RegexParseError, RegexParser, TokenMatcher}
 
-import java.util.regex.{Pattern, PatternSyntaxException}
 import scala.NamedTuple.{AnyNamedTuple, NamedTuple}
 import scala.annotation.{publicInBinary, switch}
 import scala.reflect.NameTransformer
@@ -93,10 +93,6 @@ def lexerImpl[Ctx <: LexerCtx: Type, lexemeFields <: AnyNamedTuple: Type](
         .getOrElse(raiseShouldNeverBeCalled[List[(TokenInfo, Expr[Token[?, Ctx, ?]])]](body))
         .unzip
 
-      val patterns = infos.map(_.pattern)
-      RegexChecker.checkPatterns(patterns)
-      RegexChecker.checkPatterns(patterns.reverse)
-
       (
         tokens = accTokens ::: tokens.map:
           case '{ type name <: ValidName; type tokenTpe <: Token[name, Ctx, ?]; $token: tokenTpe } =>
@@ -117,8 +113,25 @@ def lexerImpl[Ctx <: LexerCtx: Type, lexemeFields <: AnyNamedTuple: Type](
         show"Token name \"$name\" is defined ${duplicates.size.toString} times. Combine the patterns into a single case using alternatives, e.g.: case x @ (\"pattern1\" | \"pattern2\") => Token[x]",
       )
 
+  logger.trace("parsing regex patterns")
+  val parsedRegexes: List[Regex] = infos.map: info =>
+    RegexParser.parse(info.pattern) match
+      case Right(r) => r
+      case Left(err: RegexParseError.UnsupportedFeature) =>
+        report.errorAndAbort(
+          show"Unsupported regex feature `${err.feature}` at position ${err.position.toString} in pattern \"${info.pattern}\" for token \"${info.name}\"",
+        )
+      case Left(err: RegexParseError.InvalidSyntax) =>
+        report.errorAndAbort(
+          show"Invalid regex pattern \"${info.pattern}\" for token \"${info.name}\" at position ${err.position.toString}: ${err.message}. If you meant to match a literal character, escape it with a backslash (e.g., \"\\\\+\" instead of \"+\")",
+        )
+
   logger.trace("checking regex patterns")
-  RegexChecker.checkPatterns(infos.map(_.pattern))
+  val items: List[(name: String, regex: Regex)] = infos
+    .zip(parsedRegexes)
+    .map: (info, r) =>
+      (name = info.name, regex = r)
+  RegexChecker.checkRegexes(items)
 
   val fields = tokens.map((expr, name) => (name, expr.asTerm.tpe))
   val types = Refined(
@@ -138,20 +151,7 @@ def lexerImpl[Ctx <: LexerCtx: Type, lexemeFields <: AnyNamedTuple: Type](
   (refinementTpeFrom(fields).asType, fieldsTpeFrom(fields).asType, types.asType).runtimeChecked match
     case ('[refinedTpe], '[fields], '[types]) =>
       val tokensExpr = Expr.ofList(tokens.map(_.expr))
-      infos.foreach: info =>
-        try Pattern.compile(info.pattern)
-        catch
-          case e: PatternSyntaxException =>
-            report.errorAndAbort(
-              show"Invalid regex pattern \"${info.pattern}\" for token \"${info.name}\": ${e.getDescription}. If you meant to match a literal character, escape it with a backslash (e.g., \"\\\\+\" instead of \"+\")",
-            )
-
-      val regex = Expr:
-        infos
-          .map:
-            case TokenInfo(_, regexGroupName, pattern) => show"(?<$regexGroupName>$pattern)"
-          .mkString("|")
-          .tap(Pattern.compile) // we'd like to compile it here to fail in compile time if regex is invalid
+      val matcherExpr = '{ TokenMatcher.fromRegexes(${ Varargs(parsedRegexes.map(Expr(_))) }*) }
 
       '{
         {
@@ -161,7 +161,7 @@ def lexerImpl[Ctx <: LexerCtx: Type, lexemeFields <: AnyNamedTuple: Type](
 
             override def selectDynamic(name: String): Token[?, Ctx, ?] = ${ selectDynamicImpl('{ name }) }
 
-            override protected val compiled: java.util.regex.Pattern = Pattern.compile($regex)
+            override protected val matcher: TokenMatcher = $matcherExpr
         }.asInstanceOf[Tokenization[Ctx] { type LexemeFields = lexemeFields; type Fields = fields } & refinedTpe & types]
       }
 // $COVERAGE-ON$

--- a/src/alpaca/internal/lexer/RegexChecker.scala
+++ b/src/alpaca/internal/lexer/RegexChecker.scala
@@ -2,34 +2,29 @@ package alpaca
 package internal
 package lexer
 
-import dregex.Regex
-
-import scala.jdk.CollectionConverters.SeqHasAsJava
+import alpaca.internal.lexer.regex.{Regex, Subset}
 
 /**
- * Utility for checking regex patterns for shadowing issues.
+ * Cross-platform shadow detection for token regex patterns.
  *
- * This object provides methods to check if any token patterns are
- * shadowed by others, which would mean they could never be matched.
+ * A pattern is shadowed if every string it matches is also matched (as a prefix)
+ * by an earlier pattern, meaning the earlier pattern would always be selected first.
+ * Implemented via Brzozowski-derivative DFA emptiness check on `L(later · Σ*) ⊆ L(earlier · Σ*)`.
  */
 private[lexer] object RegexChecker:
 
   /**
-   * Checks a sequence of regex patterns for shadowing.
+   * Checks a priority-ordered sequence of pre-parsed regexes for shadowing.
    *
-   * A pattern is shadowed if it is a subset of an earlier pattern,
-   * meaning the earlier pattern would always match first and the
-   * shadowed pattern would never be used.
-   *
-   * @param patterns the regex patterns to check.
+   * @throws ShadowException if any pattern is shadowed by an earlier one.
    */
-  def checkPatterns(patterns: List[String])(using Log): Unit = patterns match // todo: find better way
+  def checkRegexes(items: List[(name: String, regex: Regex)])(using Log): Unit = items match
     case Nil => ()
-    case patterns =>
+    case _ =>
       logger.trace("checking regex patterns for shadowing...")
-      val regexes = Regex.compile(patterns.map(_ + ".*").asJava)
-
-      for
-        i <- patterns.indices
-        j <- (i + 1) until regexes.size
-      do if regexes.get(j).isSubsetOf(regexes.get(i)) then throw ShadowException(patterns(j), patterns(i))
+      val withSuffix = items.map((name, r) => name -> Subset.of(r).withAnySuffix)
+      withSuffix.tails.foreach:
+        case Nil => ()
+        case (earlierName, earlierSub) :: laters =>
+          laters.foreach: (laterName, laterSub) =>
+            if laterSub.subset(earlierSub) then throw ShadowException(laterName, earlierName)

--- a/src/alpaca/internal/lexer/Tokenization.scala
+++ b/src/alpaca/internal/lexer/Tokenization.scala
@@ -3,12 +3,11 @@ package internal
 package lexer
 
 import alpaca.internal.lexer.ErrorHandling.Strategy
+import alpaca.internal.lexer.regex.TokenMatcher
 
 import scala.NamedTuple.{AnyNamedTuple, NamedTuple}
 import scala.annotation.publicInBinary
 import scala.collection.mutable
-import scala.util.boundary
-import scala.util.boundary.break
 
 /**
  * The result of compiling a lexer definition.
@@ -56,44 +55,44 @@ transparent abstract class Tokenization[Ctx <: LexerCtx](
     val globalCtx = empty()
     globalCtx.text = OffsetCharSequence(input)
 
-    val matcher = compiled.matcher(globalCtx.text)
     val acc = mutable.ListBuffer.empty[Lexeme]
 
     while !globalCtx.text.isEmpty do
-      matcher.reset(globalCtx.text)
+      val (token, matched) = matcher.matchAt(globalCtx.text, 0) match
+        case Some((priority, end)) if end > 0 =>
+          val matchedStr = globalCtx.text.subSequence(0, end).toString
+          globalCtx.lastRawMatched = matchedStr
+          val found = tokensArray(priority)
+          globalCtx.text = globalCtx.text.from(end)
+          (found, matchedStr)
 
-      // noinspection ScalaUnreachableCode
-      val (token, matched) = if matcher.lookingAt then
-        val matched = matcher.group(0)
-        globalCtx.lastRawMatched = matched
-        globalCtx.text = globalCtx.text.from(matcher.end)
+        case _ =>
+          errorHandling(globalCtx) match
+            case Strategy.Throw(ex) =>
+              throw ex
 
-        val found = boundary:
-          for i <- 1 to matcher.groupCount if matcher.start(i) != -1 do break(groupToTokenMap(i))
-          throw AlgorithmError(s"${matcher.pattern} matched but no token defined for it")
+            case Strategy.IgnoreToken =>
+              matcher.findFirst(globalCtx.text, 1) match
+                case Some((firstMatching, _, _)) =>
+                  val matchedStr = globalCtx.text.subSequence(0, firstMatching).toString
+                  globalCtx.lastRawMatched = matchedStr
+                  globalCtx.text = globalCtx.text.from(firstMatching)
+                  (RecoveredToken(matchedStr), matchedStr)
+                case None =>
+                  val matchedStr = globalCtx.text.charAt(0).toString
+                  globalCtx.lastRawMatched = matchedStr
+                  globalCtx.text = globalCtx.text.from(1)
+                  (RecoveredToken(matchedStr), matchedStr)
 
-        (found, matched)
-      else
-        errorHandling(globalCtx) match
-          case Strategy.Throw(ex) =>
-            throw ex
+            case Strategy.IgnoreChar =>
+              val matchedStr = globalCtx.text.charAt(0).toString
+              globalCtx.lastRawMatched = matchedStr
+              globalCtx.text = globalCtx.text.from(1)
+              (RecoveredToken(matchedStr), matchedStr)
 
-          case Strategy.IgnoreToken if matcher.find =>
-            val firstMatching = matcher.start
-            val matched = globalCtx.text.subSequence(0, firstMatching).toString
-            globalCtx.lastRawMatched = matched
-            globalCtx.text = globalCtx.text.from(firstMatching)
-            (RecoveredToken(matched), matched)
-
-          case Strategy.IgnoreChar | Strategy.IgnoreToken =>
-            val matched = globalCtx.text.charAt(0).toString
-            globalCtx.lastRawMatched = matched
-            globalCtx.text = globalCtx.text.from(1)
-            (RecoveredToken(matched), matched)
-
-          case Strategy.Stop =>
-            globalCtx.text = ""
-            (null, null)
+            case Strategy.Stop =>
+              globalCtx.text = ""
+              (null, null)
 
       if token != null && matched != null then
         betweenStages(token, matched, globalCtx)
@@ -101,18 +100,10 @@ transparent abstract class Tokenization[Ctx <: LexerCtx](
 
     (globalCtx, acc.toList)
 
-  /** The compiled pattern that matches all defined tokens. */
-  protected def compiled: java.util.regex.Pattern
+  /** Compiled token-matcher; built at macro time. */
+  protected def matcher: TokenMatcher
 
-  private lazy val groupToTokenMap: Array[Token[?, Ctx, ?]] =
-    val matcher = compiled.matcher("")
-    val totalGroups = matcher.groupCount
-    val map = new Array[Token[?, Ctx, ?]](totalGroups + 1)
-
-    tokens.foreach: token =>
-      val groupIndex = compiled.namedGroups.get(token.info.regexGroupName)
-      if groupIndex != null then map(groupIndex) = token
-    map
+  private lazy val tokensArray: Vector[Token[?, Ctx, ?]] = tokens.toVector
 
 extension (input: CharSequence)
   private[alpaca] def from(pos: Int): CharSequence = input match

--- a/src/alpaca/internal/lexer/regex/Regex.scala
+++ b/src/alpaca/internal/lexer/regex/Regex.scala
@@ -1,0 +1,246 @@
+package alpaca
+package internal
+package lexer
+package regex
+
+import alpaca.internal.lexer.regex.Regex.{Compl, Star}
+
+import scala.annotation.tailrec
+import scala.quoted.{Expr, Quotes, ToExpr, Varargs}
+import scala.util.control.TailCalls.{done, tailcall, TailRec}
+
+/**
+ * Cross-platform symbolic regex algebra used by [[RegexChecker]] for shadow detection.
+ *
+ * Construct via smart factories on the companion ([[Regex.lit]], [[Regex.literal]],
+ * [[Regex.range]], [[Regex.apply]], [[Regex.alt]], [[Regex.inter]], [[Regex.all]]) and
+ * member combinators (`a concat b`, `a | b`, `a & b`, `!a`, `r.star`, `r.repeat(n, m)`).
+ * Raw case class constructors are inaccessible — only pattern matching via the
+ * generated `unapply` methods is allowed.
+ *
+ * Supports literals, escapes (\d \D \s \S \w \W \t \n \r and meta-escapes),
+ * character classes (including ranges and negation), `.`, alternation `|`,
+ * non-capturing-style groups `(...)`, quantifiers `*` `+` `?` `{n}` `{n,}` `{n,m}`.
+ *
+ * Unsupported (parser returns [[RegexParseError.UnsupportedFeature]]):
+ * anchors `^` `$` `\b` `\B`, lookaround `(?=` `(?!` `(?<=` `(?<!`, backreferences `\1`..`\9`.
+ */
+private[lexer] sealed trait Regex
+
+private[lexer] object Regex:
+  def apply(set: CharSet): Regex = if set.isEmpty then Empty else Chars(set)
+
+  /** Matches the empty string ε. */
+  case object Eps extends Regex
+
+  /** Matches no string. */
+  case object Empty extends Regex
+
+  /** Matches any single code point in `set`. */
+  final case class Chars private[Regex] (set: CharSet) extends Regex
+
+  /** Concatenation `a · b`. */
+  final case class Concat private[Regex] (a: Regex, b: Regex) extends Regex
+
+  /** Alternation. Stored as a [[Set]] for ACI normalization. Always size ≥ 2. */
+  final case class Alt private[Regex] (parts: Set[Regex]) extends Regex
+
+  /** Intersection. Stored as a [[Set]] for ACI normalization. Always size ≥ 2. */
+  final case class Inter private[Regex] (parts: Set[Regex]) extends Regex
+
+  /** Kleene star `r*`. */
+  final case class Star private[Regex] (r: Regex) extends Regex
+
+  /** Complement `¬r`. */
+  final case class Compl private[Regex] (r: Regex) extends Regex
+
+  extension (r: Regex)
+
+    /** Concatenation: `this · other`. */
+    infix def concat(other: Regex): Regex = Regex.concatImpl(r, other).result
+
+    /** Alternation: `this | other`. */
+    infix def |(other: Regex): Regex = Regex.alt(Set(r, other))
+
+    /** Intersection: `this ∩ other`. */
+    infix def &(other: Regex): Regex = Regex.inter(Set(r, other))
+
+    /** Complement: `¬this`. */
+    def unary_! : Regex = r match
+      case Compl(inner) => inner
+      case _ => Compl(r)
+
+    /** Kleene star: `this*`. */
+    def star: Regex = r match
+      case Eps | Empty => Eps
+      case s: Star => s
+      case _ => Star(r)
+
+    /** Quantifier `this{n,m}` where m can be `Int.MaxValue` for unbounded. */
+    def repeat(lo: Int, hi: Int): Regex =
+      require(lo >= 0 && hi >= lo, s"invalid bounds {$lo,$hi}")
+      val mandatory = (1 to lo).foldLeft[Regex](Regex.Eps)((acc, _) => r.concat(acc))
+      if hi == Int.MaxValue then mandatory.concat(star)
+      else mandatory.concat((1 to (hi - lo)).foldLeft[Regex](Regex.Eps)((acc, _) => Regex.Eps | (r.concat(acc))))
+
+  /** Alternation of a collection. */
+  def alt(parts: Iterable[Regex]): Regex =
+    val flat = parts.iterator
+      .flatMap:
+        case Alt(p) => p
+        case Empty => Iterator.empty
+        case r => Iterator.single(r)
+      .toSet
+    if flat.isEmpty then Empty
+    else if flat.sizeIs == 1 then flat.head
+    else
+      val (chars, rest) = flat.partition(_.isInstanceOf[Chars])
+      val merged: Set[Regex] =
+        if chars.sizeIs <= 1 then flat
+        else
+          val union = chars.iterator.collect { case Chars(s) => s }.foldLeft(CharSet.empty)(_ union _)
+          if union.isEmpty then rest else rest + Chars(union)
+      if merged.sizeIs == 1 then merged.head else Alt(merged)
+
+  /** Intersection of a collection. */
+  def inter(parts: Iterable[Regex]): Regex =
+    val seq = parts.iterator
+      .flatMap:
+        case Inter(p) => p
+        case r => Iterator.single(r)
+      .toSet
+    if seq.isEmpty || seq.contains(Empty) then Empty
+    else
+      val (chars, rest) = seq.partition(_.isInstanceOf[Chars])
+      val merged =
+        if chars.sizeIs <= 1 then Some(seq)
+        else
+          val isect = chars.iterator.collect { case Chars(s) => s }.reduce(_ intersect _)
+          Option.unless(isect.isEmpty)(rest + Chars(isect))
+      merged match
+        case None => Empty
+        case Some(m) if m.sizeIs == 1 => m.head
+        case Some(m) => Inter(m)
+
+  private def concatImpl(a: Regex, b: Regex): TailRec[Regex] = (a, b) match
+    case (Empty, _) | (_, Empty) => done(Empty)
+    case (Eps, x) => done(x)
+    case (x, Eps) => done(x)
+    case (Concat(x, y), z) => tailcall(concatImpl(y, z)).map(Concat(x, _))
+    case _ => done(Concat(a, b))
+
+  /** All-strings regex `Σ*`. */
+  val all: Regex = Regex(CharSet.all).star
+
+  /** Convenience: literal char. */
+  def lit(c: Char): Regex = Regex(CharSet.single(c))
+
+  /** Convenience: char range. */
+  def range(lo: Char, hi: Char): Regex = Regex(CharSet.range(lo, hi))
+
+  /** Convenience: literal string. */
+  def literal(s: String): Regex =
+    if s.isEmpty then Eps
+    else s.foldRight(Eps: Regex)((c, acc) => lit(c).concat(acc))
+
+  // $COVERAGE-OFF$
+  given ToExpr[Regex]:
+    def apply(r: Regex)(using Quotes): Expr[Regex] = r match
+      case Eps => '{ Regex.Eps }
+      case Empty => '{ Regex.Empty }
+      case Chars(set) => '{ Regex(${ Expr(set) }) }
+      case Concat(a, b) => '{ ${ Expr(a) }.concat(${ Expr(b) }) }
+      case Alt(parts) =>
+        val partsExpr = Expr.ofSeq(parts.toSeq.map(Expr(_)))
+        '{ Regex.alt($partsExpr) }
+      case Inter(parts) =>
+        val partsExpr = Expr.ofSeq(parts.toSeq.map(Expr(_)))
+        '{ Regex.inter($partsExpr) }
+      case Star(inner) => '{ ${ Expr(inner) }.star }
+      case Compl(inner) => '{ ! ${ Expr(inner) } }
+  // $COVERAGE-ON$
+
+/** Sorted, non-overlapping, merged ranges over Int code points. */
+private[regex] final case class CharSet(ranges: Vector[Range]):
+
+  def contains(c: Int): Boolean = ranges.exists(r => c >= r.lo && c <= r.hi)
+
+  def isEmpty: Boolean = ranges.isEmpty
+
+  infix def union(other: CharSet): CharSet = CharSet.normalize(ranges ++ other.ranges)
+
+  infix def intersect(other: CharSet): CharSet =
+    @tailrec
+    def loop(i: Int, j: Int, acc: Vector[Range]): Vector[Range] =
+      if i >= ranges.length || j >= other.ranges.length then acc
+      else
+        val a = ranges(i)
+        val b = other.ranges(j)
+        val lo = math.max(a.lo, b.lo)
+        val hi = math.min(a.hi, b.hi)
+        val acc1 = if lo <= hi then acc :+ Range(lo, hi) else acc
+        if a.hi < b.hi then loop(i + 1, j, acc1) else loop(i, j + 1, acc1)
+    CharSet(loop(0, 0, Vector.empty))
+
+  def complement: CharSet =
+    @tailrec
+    def loop(rs: Vector[Range], prev: Int, acc: Vector[Range]): CharSet =
+      if rs.isEmpty then
+        if prev <= CharSet.maxCodePoint then CharSet(acc :+ Range(prev, CharSet.maxCodePoint)) else CharSet(acc)
+      else
+        val head = rs.head
+        val acc1 = if prev <= head.lo - 1 then acc :+ Range(prev, head.lo - 1) else acc
+        loop(rs.tail, head.hi + 1, acc1)
+    loop(ranges, 0, Vector.empty)
+
+private[regex] object CharSet:
+
+  /** Upper bound used for complement. Covers all valid Unicode code points. */
+  val maxCodePoint: Int = 0x10ffff
+
+  val empty: CharSet = CharSet(Vector.empty)
+  val all: CharSet = CharSet(Vector(Range(0, maxCodePoint)))
+
+  /** What `.` matches in Java regex without DOTALL flag — all code points except line terminators. */
+  val dotDefault: CharSet = normalize(
+    Range(0, '\n'.toInt - 1),
+    Range('\n'.toInt + 1, '\r'.toInt - 1),
+    Range('\r'.toInt + 1, 0x84),
+    Range(0x86, 0x2027),
+    Range(0x202a, maxCodePoint),
+  )
+
+  def single(c: Char): CharSet = single(c.toInt)
+  def single(c: Int): CharSet = CharSet(Vector(Range(c, c)))
+  def range(lo: Char, hi: Char): CharSet = range(lo.toInt, hi.toInt)
+  def range(lo: Int, hi: Int): CharSet = CharSet(Vector(Range(lo, hi)))
+
+  /** Builds a normalized [[CharSet]] from arbitrary (possibly overlapping) ranges. */
+  def normalize(rs: Iterable[Range]): CharSet =
+    val (acc, last) = rs.toVector
+      .sortBy(_.lo)
+      .foldLeft((Vector.empty[Range], Option.empty[Range])):
+        case ((acc, None), r) => (acc, Some(r))
+        case ((acc, Some(cur)), r) =>
+          if r.lo <= cur.hi + 1 then (acc, Some(Range(cur.lo, math.max(cur.hi, r.hi))))
+          else (acc :+ cur, Some(r))
+    CharSet(last match
+      case None => acc
+      case Some(r) => acc :+ r)
+
+  def normalize(ranges: Range*): CharSet = normalize(ranges)
+
+  // $COVERAGE-OFF$
+  given ToExpr[CharSet]:
+    def apply(s: CharSet)(using Quotes): Expr[CharSet] =
+      val rangeExprs = s.ranges.map(r => '{ Range(${ Expr(r.lo) }, ${ Expr(r.hi) }) })
+      '{ CharSet(Vector(${ Varargs(rangeExprs) }*)) }
+  // $COVERAGE-ON$
+
+/** Single closed code-point range. */
+private[regex] type Range = (lo: Int, hi: Int)
+private[regex] object Range:
+  def apply(lo: Int, hi: Int): Range =
+    require(0 <= lo && lo <= hi && hi <= CharSet.maxCodePoint, s"invalid code-point range [$lo, $hi]")
+    (lo, hi)
+  def apply(lo: Char, hi: Char): Range = Range(lo.toInt, hi.toInt)

--- a/src/alpaca/internal/lexer/regex/RegexParser.scala
+++ b/src/alpaca/internal/lexer/regex/RegexParser.scala
@@ -1,0 +1,260 @@
+package alpaca
+package internal
+package lexer
+package regex
+
+import alpaca.internal.lexer.regex.Regex.Eps
+
+import scala.annotation.tailrec
+
+/** Reason a [[RegexParser.parse]] call did not produce a [[Regex]]. */
+private[lexer] sealed trait RegexParseError:
+  def pattern: String
+  def position: Int
+  def message: String
+
+private[lexer] object RegexParseError:
+
+  /** Pattern is syntactically malformed (unterminated group, dangling backslash, etc.). */
+  final case class InvalidSyntax(pattern: String, position: Int, message: String) extends RegexParseError
+
+  /** Pattern uses a recognized but unsupported feature (anchors, lookaround, backreferences, ...). */
+  final case class UnsupportedFeature(pattern: String, position: Int, feature: String) extends RegexParseError:
+    def message: String = s"unsupported regex feature `$feature`"
+
+/**
+ * Java-regex-style parser producing a normalized [[Regex]].
+ *
+ * Supported subset (see [[Regex]] doc): literals, escapes (\d \D \s \S \w \W \t \n \r \\
+ * and meta-escapes \. \* \+ \? \( \) \[ \] \{ \} \| \^ \$ \-), `.`, char classes
+ * `[...]` `[^...]` with ranges, alternation `|`, groups `(...)` (capturing or `(?:...)`,
+ * flag groups are NOT supported), quantifiers `*` `+` `?` `{n}` `{n,}` `{n,m}`.
+ *
+ * Unsupported: anchors `^` `$` `\b` `\B`, lookaround, backreferences `\1`..`\9`, Unicode
+ * properties `\p{...}`, named groups, flag groups.
+ */
+private[lexer] object RegexParser:
+
+  private final class InvalidSyntaxSignal(val msg: String, val pos: Int) extends RuntimeException(msg)
+  private final class UnsupportedSignal(val feature: String, val pos: Int) extends RuntimeException(feature)
+
+  private val whitespaceSet: CharSet = CharSet.normalize(
+    Range(' ', ' '),
+    Range('\t', '\t'),
+    Range('\n', '\n'),
+    Range(0x0b, 0x0b),
+    Range('\f', '\f'),
+    Range('\r', '\r'),
+  )
+
+  private val wordSet: CharSet = CharSet.normalize(
+    Range('a', 'z'),
+    Range('A', 'Z'),
+    Range('0', '9'),
+    Range('_', '_'),
+  )
+
+  /**
+   * Parse `pattern` into a [[Regex]]. Returns [[Left]] with structured error info if the
+   * pattern is malformed or uses an unsupported feature.
+   */
+  def parse(pattern: String): Either[RegexParseError, Regex] =
+    try
+      val p = new Parser(pattern)
+      val r = p.parseAlt()
+      if p.pos != pattern.length then
+        Left(RegexParseError.InvalidSyntax(pattern, p.pos, s"unexpected trailing input at position ${p.pos}"))
+      else Right(r)
+    catch
+      case e: InvalidSyntaxSignal => Left(RegexParseError.InvalidSyntax(pattern, e.pos, e.msg))
+      case e: UnsupportedSignal => Left(RegexParseError.UnsupportedFeature(pattern, e.pos, e.feature))
+
+  private final class Parser(private val src: String):
+    var pos: Int = 0
+
+    def fail(msg: String): Nothing =
+      throw new InvalidSyntaxSignal(msg, pos)
+
+    private def unsupported(feature: String): Nothing =
+      throw new UnsupportedSignal(feature, pos)
+
+    private def eof: Boolean = pos >= src.length
+
+    private def cur: Char = src.charAt(pos)
+
+    private def consume(): Char =
+      val c = src.charAt(pos)
+      pos += 1
+      c
+
+    private def expect(c: Char): Unit =
+      if eof || cur != c then fail(s"expected `$c` at position $pos")
+      pos += 1
+
+    /** alt = concat ('|' concat)* */
+    def parseAlt(): Regex =
+      @tailrec def loop(acc: Vector[Regex]): Vector[Regex] =
+        if !eof && cur == '|' then
+          pos += 1
+          loop(acc :+ parseConcat())
+        else acc
+      val parts = loop(Vector(parseConcat()))
+      if parts.sizeIs == 1 then parts.head else Regex.alt(parts)
+
+    /** concat = factor* */
+    private def parseConcat(): Regex =
+      @tailrec def loop(acc: Vector[Regex]): Vector[Regex] =
+        if eof then acc
+        else
+          cur match
+            case ')' | '|' => acc
+            case _ => loop(acc :+ parseFactor())
+      val parts = loop(Vector.empty)
+      if parts.isEmpty then Eps else parts.reduceRight(_ concat _)
+
+    /** factor = atom quantifier? */
+    private def parseFactor(): Regex =
+      val a = parseAtom()
+      if eof then a
+      else
+        cur match
+          case '*' =>
+            pos += 1
+            a.star
+          case '+' =>
+            pos += 1
+            a.concat(a.star)
+          case '?' =>
+            pos += 1
+            Eps | a
+          case '{' =>
+            pos += 1
+            parseRepeat(a)
+          case _ => a
+
+    private def parseRepeat(a: Regex): Regex =
+      val lo = readNumber()
+      if lo < 0 then fail(s"expected number after `{` at position $pos")
+      if eof then fail(s"unterminated `{` at position $pos")
+      val hi = cur match
+        case ',' =>
+          pos += 1
+          if !eof && cur == '}' then Int.MaxValue
+          else
+            val n = readNumber()
+            if n < 0 then fail(s"expected number or `}` after `,` at position $pos")
+            n
+        case '}' => lo
+        case _ => fail(s"expected `,` or `}` at position $pos")
+      expect('}')
+      if hi < lo then fail(s"invalid quantifier bounds {$lo,$hi}: upper bound must be >= lower bound")
+      a.repeat(lo, hi)
+
+    private def readNumber(): Int =
+      @tailrec def loop(p: Int): Int = if p < src.length && src.charAt(p).isDigit then loop(p + 1) else p
+
+      val end = loop(pos)
+      if end == pos then -1
+      else
+        val text = src.substring(pos, end)
+        pos = end
+        try text.toInt
+        catch case _: NumberFormatException => fail(s"quantifier value `$text` does not fit in an Int")
+
+    /** atom = group | charClass | `.` | escape | char */
+    private def parseAtom(): Regex =
+      if eof then fail("unexpected end of pattern")
+      cur match
+        case '(' => parseGroup()
+        case '[' => parseCharClass()
+        case '.' =>
+          pos += 1
+          Regex(CharSet.dotDefault)
+        case '\\' => parseEscape()
+        case '^' | '$' => unsupported(s"anchor `${consume()}`")
+        case ')' | '|' | '*' | '+' | '?' | '{' | '}' | ']' =>
+          fail(s"unexpected `$cur` at position $pos")
+        case c =>
+          pos += 1
+          Regex.lit(c)
+
+    private def parseGroup(): Regex =
+      expect('(')
+      if !eof && cur == '?' then
+        pos += 1
+        consumeGroupHeader()
+      val inner = parseAlt()
+      expect(')')
+      inner
+
+    private def consumeGroupHeader(): Unit =
+      if eof then unsupported("incomplete group header")
+      cur match
+        case ':' => pos += 1
+        case '=' | '!' => unsupported("lookahead")
+        case '<' =>
+          pos += 1
+          if !eof && (cur == '=' || cur == '!') then unsupported("lookbehind")
+          else unsupported("named group")
+        case _ => unsupported("flag group")
+
+    private def parseCharClass(): Regex =
+      expect('[')
+      val negated = !eof && cur == '^'
+      if negated then pos += 1
+      @tailrec def loop(acc: Vector[Range]): Vector[Range] =
+        if !eof && cur != ']' then
+          val lo = readClassChar()
+          val hi =
+            if !eof && cur == '-' && pos + 1 < src.length && src.charAt(pos + 1) != ']' then
+              pos += 1
+              readClassChar()
+            else lo
+          if hi < lo then fail(s"invalid character-class range `${lo.toChar}-${hi.toChar}`: end must be >= start")
+          loop(acc :+ Range(lo, hi))
+        else acc
+      val ranges = loop(Vector.empty)
+      expect(']')
+      if ranges.isEmpty then fail("empty character class")
+      val set = CharSet.normalize(ranges)
+      val finalSet = if negated then set.complement else set
+      Regex(finalSet)
+
+    private def readClassChar(): Int =
+      if eof then fail("unterminated character class")
+      cur match
+        case '\\' =>
+          pos += 1
+          readEscapedChar() match
+            case Left(_) => fail("shorthand escapes (\\d, \\s, \\w, ...) are not supported inside character classes")
+            case Right(c) => c
+        case _ => consume().toInt
+
+    private def parseEscape(): Regex =
+      expect('\\')
+      readEscapedChar() match
+        case Left(set) => Regex(set)
+        case Right(c) => Regex(CharSet.single(c))
+
+    /** Reads char following `\\`. Either expands to a [[CharSet]] (shorthand) or yields a single code point. */
+    private def readEscapedChar(): Either[CharSet, Int] =
+      if eof then fail("dangling backslash")
+      val c = src.charAt(pos)
+      pos += 1
+      c match
+        case 'd' => Left(CharSet.range('0', '9'))
+        case 'D' => Left(CharSet.range('0', '9').complement)
+        case 's' => Left(whitespaceSet)
+        case 'S' => Left(whitespaceSet.complement)
+        case 'w' => Left(wordSet)
+        case 'W' => Left(wordSet.complement)
+        case 't' => Right('\t'.toInt)
+        case 'n' => Right('\n'.toInt)
+        case 'r' => Right('\r'.toInt)
+        case 'f' => Right('\f'.toInt)
+        case '0' => Right(0)
+        case 'b' | 'B' => unsupported(s"word boundary `\\$c`")
+        case 'A' | 'z' | 'Z' => unsupported(s"anchor `\\$c`")
+        case 'p' | 'P' => unsupported("Unicode property")
+        case d if d.isDigit => unsupported(s"backreference `\\$d`")
+        case _ => Right(c.toInt)

--- a/src/alpaca/internal/lexer/regex/Subset.scala
+++ b/src/alpaca/internal/lexer/regex/Subset.scala
@@ -1,0 +1,163 @@
+package alpaca
+package internal
+package lexer
+package regex
+
+import alpaca.internal.lexer.regex.Regex.*
+
+import scala.collection.immutable.SortedSet
+import scala.util.control.TailCalls.{done, tailcall, TailRec}
+
+/**
+ * Opaque view over a [[Regex]] exposing Brzozowski-derivative based language emptiness
+ * and subset operations.
+ *
+ * `a.subset(b)` decides whether `L(a) ⊆ L(b)` by checking emptiness of `a ∩ ¬b`.
+ * Termination relies on smart-constructor normalization in [[Regex]] keeping the
+ * derivative state set finite up to similarity.
+ */
+opaque private[lexer] type Subset = Regex
+
+private[lexer] object Subset:
+
+  /** Lifts an existing [[Regex]] into [[Subset]]. */
+  def of(r: Regex): Subset = r
+
+  /** Parses a pattern into a [[Subset]]. */
+  def parse(pattern: String): Either[RegexParseError, Subset] = RegexParser.parse(pattern).map(of)
+
+  /** The empty-language subset; reference-equal to [[Regex.Empty]] under the opaque type. */
+  val empty: Subset = of(Regex.Empty)
+
+  extension (a: Subset)
+    /** Underlying [[Regex]]. */
+    def underlying: Regex = a
+
+    /** `Σ*`-extended view — matches every string having `a` as prefix. */
+    def withAnySuffix: Subset = a.concat(Regex.all)
+
+    /** `true` iff `L(a) ⊆ L(b)`. */
+    def subset(b: Subset): Boolean = (a & !b).isEmpty
+
+    /** `true` iff `L(a) = ∅`. */
+    def isEmpty: Boolean = isEmptyImpl(a)
+
+    /** `true` iff `ε ∈ L(a)`. */
+    def nullable: Boolean = nullableImpl(a).result
+
+    /** Brzozowski derivative of `a` with respect to code point `c`. */
+    def derive(c: Int): Subset = deriveImpl(a, c).result
+
+  private def isEmptyImpl(r: Regex): Boolean =
+    def loop(queue: List[Regex], visited: Set[Regex]): TailRec[Boolean] = queue match
+      case Nil => done(true)
+      case s :: rest =>
+        for
+          isNull <- tailcall(nullableImpl(s))
+          out <-
+            if isNull then done(false)
+            else
+              for
+                derived <- tailcall(deriveAt(partitionReps(s), s, Nil))
+                next = derived.filterNot(visited.contains)
+                r <- tailcall(loop(rest ::: next, visited ++ next))
+              yield r
+        yield out
+    loop(List(r), Set(r)).result
+
+  private def nullableImpl(r: Regex): TailRec[Boolean] = r match
+    case Eps => done(true)
+    case Empty | Chars(_) => done(false)
+    case Concat(a, b) =>
+      for
+        na <- tailcall(nullableImpl(a))
+        out <- if na then tailcall(nullableImpl(b)) else done(false)
+      yield out
+    case Alt(parts) => anyNullable(parts.toList)
+    case Inter(parts) => allNullable(parts.toList)
+    case Star(_) => done(true)
+    case Compl(inner) => tailcall(nullableImpl(inner)).map(!_)
+
+  private def anyNullable(parts: List[Regex]): TailRec[Boolean] = parts match
+    case Nil => done(false)
+    case head :: tail =>
+      for
+        hd <- tailcall(nullableImpl(head))
+        out <- if hd then done(true) else tailcall(anyNullable(tail))
+      yield out
+
+  private def allNullable(parts: List[Regex]): TailRec[Boolean] = parts match
+    case Nil => done(true)
+    case head :: tail =>
+      for
+        hd <- tailcall(nullableImpl(head))
+        out <- if !hd then done(false) else tailcall(allNullable(tail))
+      yield out
+
+  private def deriveImpl(r: Regex, c: Int): TailRec[Regex] = r match
+    case Eps | Empty => done(Empty)
+    case Chars(set) => done(if set.contains(c) then Eps else Empty)
+    case Concat(a, b) =>
+      for
+        da <- tailcall(deriveImpl(a, c))
+        na <- tailcall(nullableImpl(a))
+        out <-
+          if na then tailcall(deriveImpl(b, c)).map(db => (da.concat(b)) | db)
+          else done(da.concat(b))
+      yield out
+    case Alt(parts) => deriveAll(parts.toList, c, Nil).map(Regex.alt)
+    case Inter(parts) => deriveAll(parts.toList, c, Nil).map(Regex.inter)
+    case s @ Star(inner) => tailcall(deriveImpl(inner, c)).map(d => d.concat(s))
+    case Compl(inner) => tailcall(deriveImpl(inner, c)).map(!_)
+
+  private def deriveAll(parts: List[Regex], c: Int, acc: List[Regex]): TailRec[List[Regex]] = parts match
+    case Nil => done(acc)
+    case head :: tail =>
+      for
+        d <- tailcall(deriveImpl(head, c))
+        out <- tailcall(deriveAll(tail, c, d :: acc))
+      yield out
+
+  private def deriveAt(reps: List[Int], r: Regex, acc: List[Regex]): TailRec[List[Regex]] = reps match
+    case Nil => done(acc)
+    case c :: tail =>
+      for
+        d <- tailcall(deriveImpl(r, c))
+        out <- tailcall(deriveAt(tail, r, d :: acc))
+      yield out
+
+  /**
+   * Returns one representative code point per equivalence class of the alphabet
+   * partition induced by the character sets in `r`. Within a class, derivatives
+   * yield the same residual, so testing one representative suffices.
+   */
+  private def partitionReps(r: Regex): List[Int] =
+    val boundaries = collectBoundaries(r, SortedSet[Int](0, CharSet.maxCodePoint + 1)).result.toVector
+    boundaries.init.toList
+
+  private def collectBoundaries(r: Regex, acc: SortedSet[Int]): TailRec[SortedSet[Int]] = r match
+    case Eps | Empty => done(acc)
+    case Chars(set) => tailcall(addBoundaries(set.ranges.toList, acc))
+    case Concat(a, b) =>
+      for
+        a1 <- tailcall(collectBoundaries(a, acc))
+        a2 <- tailcall(collectBoundaries(b, a1))
+      yield a2
+    case Alt(parts) => collectAllBoundaries(parts.toList, acc)
+    case Inter(parts) => collectAllBoundaries(parts.toList, acc)
+    case Star(inner) => tailcall(collectBoundaries(inner, acc))
+    case Compl(inner) => tailcall(collectBoundaries(inner, acc))
+
+  private def addBoundaries(ranges: List[Range], acc: SortedSet[Int]): TailRec[SortedSet[Int]] =
+    ranges match
+      case Nil => done(acc)
+      case head :: tail => tailcall(addBoundaries(tail, acc + head.lo + (head.hi + 1)))
+
+  private def collectAllBoundaries(parts: List[Regex], acc: SortedSet[Int]): TailRec[SortedSet[Int]] =
+    parts match
+      case Nil => done(acc)
+      case head :: tail =>
+        for
+          next <- tailcall(collectBoundaries(head, acc))
+          out <- tailcall(collectAllBoundaries(tail, next))
+        yield out

--- a/src/alpaca/internal/lexer/regex/TokenMatcher.scala
+++ b/src/alpaca/internal/lexer/regex/TokenMatcher.scala
@@ -3,53 +3,147 @@ package internal
 package lexer
 package regex
 
+import scala.collection.mutable
+
 /**
  * Lexer-style longest-match tokenizer over a priority-ordered list of patterns.
  *
  * Simulates a tagged Brzozowski-derivative DFA in parallel for all patterns. Returns
  * the longest prefix match across all patterns; ties broken by lowest priority index
  * (i.e., the first pattern in the input list wins).
+ *
+ * States are interned to integer IDs the first time they are reached; transitions
+ * (per state, per code point) are then cached in flat arrays indexed by state ID.
+ * After warm-up the hot loop is pure integer array indexing — no `Subset` equality,
+ * no `HashMap` lookups, no per-character allocation.
  */
-opaque private[lexer] type TokenMatcher = Vector[Subset]
+final class TokenMatcher private[regex] (initial: Array[Subset]):
 
-private[lexer] object TokenMatcher:
+  private val stateToId = mutable.HashMap.empty[Vector[Subset], Int]
+  private var idToState: Array[Vector[Subset]] = new Array(16)
+  private var asciiTrans: Array[Array[Int]] = new Array(16)
+  private var unicodeTrans: Array[mutable.HashMap[Int, Int]] = new Array(16)
+  private var stateInfo: Array[StateInfo] = new Array(16)
+  private var stateCount: Int = 0
+
+  private val initialId = registerState(initial.toVector)
+
+  private def grow(): Unit =
+    val n = asciiTrans.length * 2
+    idToState = java.util.Arrays.copyOf(idToState, n)
+    asciiTrans = java.util.Arrays.copyOf(asciiTrans, n)
+    unicodeTrans = java.util.Arrays.copyOf(unicodeTrans, n)
+    val newInfo = new Array[StateInfo](n)
+    System.arraycopy(stateInfo, 0, newInfo, 0, stateCount)
+    stateInfo = newInfo
+
+  private def registerState(s: Vector[Subset]): Int =
+    stateToId.get(s) match
+      case Some(id) => id
+      case None =>
+        if stateCount >= asciiTrans.length then grow()
+        val id = stateCount
+        stateToId(s) = id
+        idToState(id) = s
+        val arr = new Array[Int](128)
+        java.util.Arrays.fill(arr, -1)
+        asciiTrans(id) = arr
+        unicodeTrans(id) = mutable.HashMap.empty
+        stateInfo(id) = infoFor(s)
+        stateCount += 1
+        id
+
+  private def infoFor(s: Vector[Subset]): StateInfo =
+    if s.forall(_ == Subset.empty) then StateInfo.Dead
+    else
+      val p = firstNullablePriority(s)
+      if p >= 0 then StateInfo.Accept(p) else StateInfo.Live
+
+  private def transition(fromId: Int, c: Int): Int =
+    if c < 128 then asciiTransition(fromId, c)
+    else unicodeTrans(fromId).getOrElseUpdate(c, registerState(idToState(fromId).map(_.derive(c))))
+
+  private def asciiTransition(fromId: Int, c: Int): Int =
+    val arr = asciiTrans(fromId)
+    val cached = arr(c)
+    if cached >= 0 then cached
+    else
+      val nextId = registerState(idToState(fromId).map(_.derive(c)))
+      asciiTrans(fromId)(c) = nextId
+      nextId
+
+  /**
+   * Match a token starting at `start` in `input`.
+   *
+   * @return `Some((priority, end))` where `priority` is the index of the winning
+   *         pattern and `end` is the exclusive end of the longest match. `None` if
+   *         no pattern matches any (possibly empty) prefix at `start`.
+   */
+  def matchAt(input: CharSequence, start: Int): Option[(priority: Int, end: Int)] =
+    var sid = initialId
+    var info: StateInfo = stateInfo(sid)
+    var lastPriority = if info.isAccepting then info.priority else -1
+    var lastEnd = start
+    var i = start
+    val len = input.length
+    while i < len && !info.isDead do
+      val ch = input.charAt(i)
+      if ch < 128 then
+        sid = asciiTransition(sid, ch.toInt)
+        i += 1
+      else
+        val c = Character.codePointAt(input, i)
+        sid = transition(sid, c)
+        i += Character.charCount(c)
+      info = stateInfo(sid)
+      if info.isAccepting then
+        lastPriority = info.priority
+        lastEnd = i
+    if lastPriority >= 0 then Some((priority = lastPriority, end = lastEnd)) else None
+
+  /** First position `>= from` at which some pattern matches a non-empty prefix. */
+  def findFirst(input: CharSequence, from: Int): Option[(start: Int, priority: Int, end: Int)] =
+    var p = from
+    var result: (start: Int, priority: Int, end: Int) | Null = null
+    while result == null && p < input.length do
+      matchAt(input, p) match
+        case Some((priority, end)) if end > p =>
+          result = (start = p, priority = priority, end = end)
+        case _ =>
+          p += Character.charCount(Character.codePointAt(input, p))
+    Option(result)
+
+  private def firstNullablePriority(s: Vector[Subset]): Int =
+    var k = 0
+    while k < s.length do
+      if s(k).nullable then return k
+      k += 1
+    -1
+
+/**
+ * Compact per-state status carried alongside the transition table.
+ *
+ * Encoded as a single [[Int]]:
+ *   - `Int.MinValue` — dead state (no future transition can reach an accept)
+ *   - `-1`           — live, not currently accepting
+ *   - `>= 0`         — accepting; the value is the winning pattern's priority index
+ */
+opaque private[regex] type StateInfo = Int
+
+private[regex] object StateInfo:
+  val Dead: StateInfo = Int.MinValue
+  val Live: StateInfo = -1
+  def Accept(priority: Int): StateInfo =
+    require(priority >= 0, s"accept priority must be non-negative, got $priority")
+    priority
+
+  extension (s: StateInfo)
+    inline def isDead: Boolean = s == Int.MinValue
+    inline def isAccepting: Boolean = s >= 0
+    inline def priority: Int = s
+
+object TokenMatcher:
 
   /** Build a matcher from pre-parsed regexes (use this from macros after compile-time parsing). */
-  def fromRegexes(initial: Regex*): TokenMatcher = initial.iterator.map(Subset.of).toVector
-
-  extension (m: TokenMatcher)
-
-    /**
-     * Match a token starting at `start` in `input`.
-     *
-     * @return `Some((priority, end))` where `priority` is the index of the winning
-     *         pattern and `end` is the exclusive end of the longest match. `None` if
-     *         no pattern matches any (possibly empty) prefix at `start`.
-     */
-    def matchAt(input: CharSequence, start: Int): Option[(priority: Int, end: Int)] =
-      codePointStarts(input, start)
-        .map(p => (Character.codePointAt(input, p), p))
-        .scanLeft((m, start)):
-          case ((st, _), (c, p)) => (st.map(_.derive(c)), p + Character.charCount(c))
-        .takeWhile((st, _) => !st.allEmpty)
-        .flatMap((st, p) => st.firstNullable.map(idx => (priority = idx, end = p)))
-        .foldLeft(Option.empty[(priority: Int, end: Int)])((_, hit) => Some(hit))
-
-    /** First position `>= from` at which some pattern matches a non-empty prefix. */
-    def findFirst(input: CharSequence, from: Int): Option[(start: Int, priority: Int, end: Int)] =
-      codePointStarts(input, from)
-        .map(start => (start, m.matchAt(input, start)))
-        .collectFirst:
-          case (start, Some((priority, end))) if end > start => (start, priority, end)
-
-  /** Iterator of code-point start offsets in `input`, beginning at `from`. */
-  private def codePointStarts(input: CharSequence, from: Int): Iterator[Int] =
-    Iterator
-      .iterate(from)(p => p + Character.charCount(Character.codePointAt(input, p)))
-      .takeWhile(_ < input.length)
-
-  extension (s: Vector[Subset])
-    private def firstNullable: Option[Int] = s.iterator.zipWithIndex.collectFirst:
-      case (sub, idx) if sub.nullable => idx
-
-    private def allEmpty: Boolean = s.forall(_ == Subset.empty)
+  def fromRegexes(initial: Regex*): TokenMatcher =
+    TokenMatcher(initial.iterator.map(Subset.of).toArray)

--- a/src/alpaca/internal/lexer/regex/TokenMatcher.scala
+++ b/src/alpaca/internal/lexer/regex/TokenMatcher.scala
@@ -1,0 +1,55 @@
+package alpaca
+package internal
+package lexer
+package regex
+
+/**
+ * Lexer-style longest-match tokenizer over a priority-ordered list of patterns.
+ *
+ * Simulates a tagged Brzozowski-derivative DFA in parallel for all patterns. Returns
+ * the longest prefix match across all patterns; ties broken by lowest priority index
+ * (i.e., the first pattern in the input list wins).
+ */
+opaque private[lexer] type TokenMatcher = Vector[Subset]
+
+private[lexer] object TokenMatcher:
+
+  /** Build a matcher from pre-parsed regexes (use this from macros after compile-time parsing). */
+  def fromRegexes(initial: Regex*): TokenMatcher = initial.iterator.map(Subset.of).toVector
+
+  extension (m: TokenMatcher)
+
+    /**
+     * Match a token starting at `start` in `input`.
+     *
+     * @return `Some((priority, end))` where `priority` is the index of the winning
+     *         pattern and `end` is the exclusive end of the longest match. `None` if
+     *         no pattern matches any (possibly empty) prefix at `start`.
+     */
+    def matchAt(input: CharSequence, start: Int): Option[(priority: Int, end: Int)] =
+      codePointStarts(input, start)
+        .map(p => (Character.codePointAt(input, p), p))
+        .scanLeft((m, start)):
+          case ((st, _), (c, p)) => (st.map(_.derive(c)), p + Character.charCount(c))
+        .takeWhile((st, _) => !st.allEmpty)
+        .flatMap((st, p) => st.firstNullable.map(idx => (priority = idx, end = p)))
+        .foldLeft(Option.empty[(priority: Int, end: Int)])((_, hit) => Some(hit))
+
+    /** First position `>= from` at which some pattern matches a non-empty prefix. */
+    def findFirst(input: CharSequence, from: Int): Option[(start: Int, priority: Int, end: Int)] =
+      codePointStarts(input, from)
+        .map(start => (start, m.matchAt(input, start)))
+        .collectFirst:
+          case (start, Some((priority, end))) if end > start => (start, priority, end)
+
+  /** Iterator of code-point start offsets in `input`, beginning at `from`. */
+  private def codePointStarts(input: CharSequence, from: Int): Iterator[Int] =
+    Iterator
+      .iterate(from)(p => p + Character.charCount(Character.codePointAt(input, p)))
+      .takeWhile(_ < input.length)
+
+  extension (s: Vector[Subset])
+    private def firstNullable: Option[Int] = s.iterator.zipWithIndex.collectFirst:
+      case (sub, idx) if sub.nullable => idx
+
+    private def allEmpty: Boolean = s.forall(_ == Subset.empty)

--- a/test/src/alpaca/internal/lexer/ErrorHandlingStrategyTest.scala
+++ b/test/src/alpaca/internal/lexer/ErrorHandlingStrategyTest.scala
@@ -4,8 +4,6 @@ package internal.lexer
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import java.util.regex.Pattern
-
 final class ErrorHandlingStrategyTest extends AnyFunSuite with Matchers:
 
   test("Strategy.Throw should throw the provided exception") {

--- a/test/src/alpaca/internal/lexer/RegexCheckerTest.scala
+++ b/test/src/alpaca/internal/lexer/RegexCheckerTest.scala
@@ -2,6 +2,8 @@ package alpaca
 package internal
 package lexer
 
+import alpaca.internal.lexer.regex.{Regex, RegexParser}
+
 import org.scalatest.LoneElement
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -9,84 +11,118 @@ import org.scalatest.matchers.should.Matchers
 final class RegexCheckerTest extends AnyFunSuite with Matchers with LoneElement:
   private given DebugSettings = DebugSettings.default
 
-  test("checkPatterns should return None for non-overlapping patterns") {
+  private def items(patterns: String*): List[(name: String, regex: Regex)] =
+    patterns.toList.map: p =>
+      RegexParser.parse(p) match
+        case Right(r) => (name = p, regex = r)
+        case Left(err) => fail(s"expected successful parse of /$p/, got $err")
+
+  test("checkRegexes should pass for non-overlapping patterns") {
     withLog:
-      val patterns = List(
-        "[a-zA-Z_][a-zA-Z0-9_]*",
-        "[+-]?[0-9]+",
-        "=",
-        "[ \\t\\n]+",
-      )
       noException shouldBe thrownBy:
-        RegexChecker.checkPatterns(patterns)
+        RegexChecker.checkRegexes(
+          items(
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "[+-]?[0-9]+",
+            "=",
+            "[ \\t\\n]+",
+          ),
+        )
   }
 
-  test("checkPatterns should throw ShadowException for overlapping patterns") {
+  test("checkRegexes should throw ShadowException for overlapping patterns") {
     withLog:
-      val patterns = List(
-        "[a-zA-Z_][a-zA-Z0-9_]*",
-        "\\*",
-        "=",
-        "[a-zA-Z]+",
-        "[ \\t\\n]+",
-      )
       intercept[ShadowException]:
-        RegexChecker.checkPatterns(patterns)
+        RegexChecker.checkRegexes(
+          items(
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "\\*",
+            "=",
+            "[a-zA-Z]+",
+            "[ \\t\\n]+",
+          ),
+        )
       .getMessage should include("Pattern [a-zA-Z]+ is shadowed by [a-zA-Z_][a-zA-Z0-9_]*")
   }
 
-  test("checkPatterns should report prefix shadowing") {
+  test("checkRegexes should report prefix shadowing") {
     withLog:
-      val patterns = List(
-        "i",
-        "\\*",
-        "if",
-        "=",
-        "[a-zA-Z]+",
-        "[ \\t\\n]+",
-      )
       intercept[ShadowException]:
-        RegexChecker.checkPatterns(patterns)
+        RegexChecker.checkRegexes(
+          items(
+            "i",
+            "\\*",
+            "if",
+            "=",
+            "[a-zA-Z]+",
+            "[ \\t\\n]+",
+          ),
+        )
       .getMessage should include("Pattern if is shadowed by i")
   }
 
-  test("checkPatterns should report identical patterns as overlapping") {
+  test("checkRegexes should report identical patterns as overlapping") {
     withLog:
-      val patterns = List(
-        "[a-zA-Z_][a-zA-Z0-9_]*",
-        "\\*",
-        "=",
-        "[a-zA-Z_][a-zA-Z0-9_]*",
-        "[ \\t\\n]+",
-      )
       intercept[ShadowException]:
-        RegexChecker.checkPatterns(patterns)
+        RegexChecker.checkRegexes(
+          items(
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "\\*",
+            "=",
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "[ \\t\\n]+",
+          ),
+        )
       .getMessage should include("Pattern [a-zA-Z_][a-zA-Z0-9_]* is shadowed by [a-zA-Z_][a-zA-Z0-9_]*")
   }
 
-  test("checkPatterns should not report patterns in proper order") {
+  test("checkRegexes should not report patterns in proper order") {
     withLog:
-      val patterns = List(
-        "if",
-        "\\*",
-        "when",
-        "i",
-        "=",
-        "[a-zA-Z_][a-zA-Z0-9_]*",
-        "[ \\t\\n]+",
-      )
       noException shouldBe thrownBy:
-        RegexChecker.checkPatterns(patterns)
+        RegexChecker.checkRegexes(
+          items(
+            "if",
+            "\\*",
+            "when",
+            "i",
+            "=",
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "[ \\t\\n]+",
+          ),
+        )
   }
 
-  test("checkPatterns should handle empty pattern list") {
+  test("checkRegexes should handle empty pattern list") {
     withLog:
       noException shouldBe thrownBy:
-        RegexChecker.checkPatterns(Nil)
+        RegexChecker.checkRegexes(Nil)
   }
 
-  test("checkPatterns should handle single pattern") {
+  test("checkRegexes should handle single pattern") {
     withLog:
       noException shouldBe thrownBy:
-        RegexChecker.checkPatterns(List("[a-zA-Z_][a-zA-Z0-9_]*"))
+        RegexChecker.checkRegexes(items("[a-zA-Z_][a-zA-Z0-9_]*"))
+  }
+
+  test("handles CalcLexer-like patterns") {
+    withLog:
+      noException shouldBe thrownBy:
+        RegexChecker.checkRegexes(
+          items(
+            " ",
+            "\\t",
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "\\+",
+            "-",
+            "\\*",
+            "/",
+            "=",
+            ",",
+            "\\(",
+            "\\)",
+            "\\d+",
+            "#.*",
+            "\n+",
+          ),
+        )
   }

--- a/test/src/alpaca/internal/lexer/regex/CharSetTest.scala
+++ b/test/src/alpaca/internal/lexer/regex/CharSetTest.scala
@@ -1,0 +1,171 @@
+package alpaca
+package internal
+package lexer
+package regex
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+final class CharSetTest extends AnyFunSuite with Matchers:
+
+  test("contains decides membership") {
+    val s = CharSet.range('a', 'z')
+    s.contains('a'.toInt) shouldBe true
+    s.contains('z'.toInt) shouldBe true
+    s.contains('m'.toInt) shouldBe true
+    s.contains('A'.toInt) shouldBe false
+    s.contains(('a' - 1).toInt) shouldBe false
+  }
+
+  test("union merges overlapping ranges") {
+    val a = CharSet.range('a', 'm')
+    val b = CharSet.range('h', 'z')
+    val u = a.union(b)
+    u.ranges shouldBe Vector(Range('a', 'z'))
+  }
+
+  test("union keeps disjoint ranges separate") {
+    val a = CharSet.range('a', 'c')
+    val b = CharSet.range('x', 'z')
+    val u = a.union(b)
+    u.ranges shouldBe Vector(Range('a', 'c'), Range('x', 'z'))
+  }
+
+  test("union merges adjacent ranges") {
+    val a = CharSet.range('a', 'c')
+    val b = CharSet.range('d', 'f')
+    val u = a.union(b)
+    u.ranges shouldBe Vector(Range('a', 'f'))
+  }
+
+  test("intersect computes overlap") {
+    val a = CharSet.range('a', 'm')
+    val b = CharSet.range('h', 'z')
+    a.intersect(b).ranges shouldBe Vector(Range('h', 'm'))
+  }
+
+  test("intersect of disjoint is empty") {
+    val a = CharSet.range('a', 'c')
+    val b = CharSet.range('x', 'z')
+    a.intersect(b).isEmpty shouldBe true
+  }
+
+  test("complement of all is empty, of empty is all") {
+    CharSet.all.complement.isEmpty shouldBe true
+    CharSet.empty.complement shouldBe CharSet.all
+  }
+
+  test("complement excludes original ranges") {
+    val s = CharSet.range('a', 'z').complement
+    s.contains('a'.toInt) shouldBe false
+    s.contains('z'.toInt) shouldBe false
+    s.contains('A'.toInt) shouldBe true
+    s.contains(('a' - 1).toInt) shouldBe true
+    s.contains(('z' + 1).toInt) shouldBe true
+  }
+
+  test("normalize merges overlapping and adjacent ranges") {
+    val s = CharSet.normalize(Range('a', 'c'), Range('b', 'e'), Range('f', 'h'))
+    s.ranges shouldBe Vector(Range('a', 'h'))
+  }
+
+  test("normalize sorts unsorted input") {
+    val s = CharSet.normalize(Range('x', 'z'), Range('a', 'c'))
+    s.ranges shouldBe Vector(Range('a', 'c'), Range('x', 'z'))
+  }
+
+  test("dotDefault excludes line terminators") {
+    CharSet.dotDefault.contains('\n'.toInt) shouldBe false
+    CharSet.dotDefault.contains('\r'.toInt) shouldBe false
+    CharSet.dotDefault.contains(0x85) shouldBe false
+    CharSet.dotDefault.contains(0x2028) shouldBe false
+    CharSet.dotDefault.contains(0x2029) shouldBe false
+    CharSet.dotDefault.contains('a'.toInt) shouldBe true
+  }
+
+  test("empty set contains nothing") {
+    CharSet.empty.contains('a'.toInt) shouldBe false
+    CharSet.empty.contains(0) shouldBe false
+    CharSet.empty.isEmpty shouldBe true
+  }
+
+  test("all set contains every code point in range") {
+    CharSet.all.contains(0) shouldBe true
+    CharSet.all.contains('a'.toInt) shouldBe true
+    CharSet.all.contains(CharSet.maxCodePoint) shouldBe true
+  }
+
+  test("union is commutative") {
+    val a = CharSet.range('a', 'm')
+    val b = CharSet.range('h', 'z')
+    a.union(b) shouldBe b.union(a)
+  }
+
+  test("union with self is self") {
+    val a = CharSet.range('a', 'z')
+    a.union(a) shouldBe a
+  }
+
+  test("union with empty is self") {
+    val a = CharSet.range('a', 'z')
+    a.union(CharSet.empty) shouldBe a
+    CharSet.empty.union(a) shouldBe a
+  }
+
+  test("intersect is commutative") {
+    val a = CharSet.range('a', 'm')
+    val b = CharSet.range('h', 'z')
+    a.intersect(b) shouldBe b.intersect(a)
+  }
+
+  test("intersect with self is self") {
+    val a = CharSet.range('a', 'z')
+    a.intersect(a) shouldBe a
+  }
+
+  test("intersect with empty is empty") {
+    val a = CharSet.range('a', 'z')
+    a.intersect(CharSet.empty).isEmpty shouldBe true
+    CharSet.empty.intersect(a).isEmpty shouldBe true
+  }
+
+  test("intersect with all is self") {
+    val a = CharSet.range('a', 'z')
+    a.intersect(CharSet.all) shouldBe a
+  }
+
+  test("double complement returns to original") {
+    val a = CharSet.range('a', 'z')
+    a.complement.complement shouldBe a
+  }
+
+  test("normalize merges multiple adjacent ranges") {
+    val s = CharSet.normalize(
+      Range('a', 'b'),
+      Range('c', 'd'),
+      Range('e', 'f'),
+    )
+    s.ranges shouldBe Vector(Range('a', 'f'))
+  }
+
+  test("normalize keeps non-overlapping ranges separate") {
+    val s = CharSet.normalize(
+      Range('a', 'c'),
+      Range('f', 'h'),
+      Range('m', 'p'),
+    )
+    s.ranges shouldBe Vector(
+      Range('a', 'c'),
+      Range('f', 'h'),
+      Range('m', 'p'),
+    )
+  }
+
+  test("normalize handles duplicate ranges") {
+    val s = CharSet.normalize(Range('a', 'z'), Range('a', 'z'))
+    s.ranges shouldBe Vector(Range('a', 'z'))
+  }
+
+  test("single from Int and Char agree") {
+    CharSet.single('a') shouldBe CharSet.single('a'.toInt)
+  }

--- a/test/src/alpaca/internal/lexer/regex/RegexAlgebraTest.scala
+++ b/test/src/alpaca/internal/lexer/regex/RegexAlgebraTest.scala
@@ -1,0 +1,135 @@
+package alpaca
+package internal
+package lexer
+package regex
+
+import alpaca.internal.lexer.regex.Regex.*
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+final class RegexAlgebraTest extends AnyFunSuite with Matchers:
+
+  private val rA = Regex.lit('a')
+  private val rB = Regex.lit('b')
+  private val rC = Regex.lit('c')
+
+  // concat ----------------------------------------------------------------
+
+  test("concat with Empty annihilates") {
+    (Empty.concat(rA)) shouldBe Empty
+    (rA.concat(Empty)) shouldBe Empty
+  }
+
+  test("concat with Eps is identity") {
+    (Eps.concat(rA)) shouldBe rA
+    (rA.concat(Eps)) shouldBe rA
+  }
+
+  test("concat is right-associated") {
+    rA.concat(rB).concat(rC) match
+      case Concat(a, Concat(b, c)) => (a, b, c) shouldBe (rA, rB, rC)
+      case other => fail(s"not right-associated: $other")
+  }
+
+  // alt -------------------------------------------------------------------
+
+  test("alt with Empty drops it") {
+    (Empty | rA) shouldBe rA
+    (rA | Empty) shouldBe rA
+  }
+
+  test("alt deduplicates equal regexes") {
+    (rA | rA) shouldBe rA
+  }
+
+  test("alt flattens nested Alt") {
+    val sA = rA.star
+    val sB = rB.star
+    val sC = rC.star
+    sA | sB | sC match
+      case Alt(parts) => parts shouldBe Set(sA, sB, sC)
+      case other => fail(s"not flattened Alt: $other")
+  }
+
+  test("alt merges Chars by union") {
+    val merged = Regex.lit('a') | Regex.lit('b')
+    merged shouldBe Regex(CharSet.normalize(('a'.toInt, 'a'.toInt), ('b'.toInt, 'b'.toInt)))
+  }
+
+  // inter -----------------------------------------------------------------
+
+  test("inter with Empty gives Empty") {
+    (Empty & rA) shouldBe Empty
+    (rA & Empty) shouldBe Empty
+  }
+
+  test("inter deduplicates equal regexes") {
+    (rA & rA) shouldBe rA
+  }
+
+  test("inter intersects Chars") {
+    val ab = Regex.range('a', 'm')
+    val bc = Regex.range('h', 'z')
+    (ab & bc) shouldBe Regex.range('h', 'm')
+  }
+
+  test("inter of disjoint Chars is Empty") {
+    (Regex.lit('a') & Regex.lit('b')) shouldBe Empty
+  }
+
+  // star ------------------------------------------------------------------
+
+  test("star of Eps is Eps") {
+    Eps.star shouldBe Eps
+  }
+
+  test("star of Empty is Eps") {
+    Empty.star shouldBe Eps
+  }
+
+  test("star of Star is the same Star") {
+    val s = rA.star
+    s.star shouldBe s
+  }
+
+  // compl -----------------------------------------------------------------
+
+  test("compl is involutive") {
+    !(!rA) shouldBe rA
+  }
+
+  // literal ---------------------------------------------------------------
+
+  test("literal of empty string is Eps") {
+    Regex.literal("") shouldBe Eps
+  }
+
+  test("literal of single char is Chars") {
+    Regex.literal("a") shouldBe Regex.lit('a')
+  }
+
+  test("literal of two chars is right-associated Concat") {
+    Regex.literal("ab") match
+      case Concat(a, b) => (a, b) shouldBe (Regex.lit('a'), Regex.lit('b'))
+      case other => fail(s"not Concat: $other")
+  }
+
+  // repeat ----------------------------------------------------------------
+
+  test("repeat {0} is Eps") {
+    rA.repeat(0, 0) shouldBe Eps
+  }
+
+  test("repeat {1,1} is the regex itself") {
+    rA.repeat(1, 1) shouldBe rA
+  }
+
+  test("repeat {n, MaxValue} ends with Star") {
+    rA.repeat(2, Int.MaxValue) shouldBe (rA.concat(rA).concat(rA.star))
+  }
+
+  test("repeat rejects invalid bounds") {
+    an[IllegalArgumentException] shouldBe thrownBy(rA.repeat(-1, 0))
+    an[IllegalArgumentException] shouldBe thrownBy(rA.repeat(3, 2))
+  }

--- a/test/src/alpaca/internal/lexer/regex/RegexParserTest.scala
+++ b/test/src/alpaca/internal/lexer/regex/RegexParserTest.scala
@@ -1,0 +1,210 @@
+package alpaca
+package internal
+package lexer
+package regex
+
+import alpaca.internal.lexer.regex.Regex.*
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+final class RegexParserTest extends AnyFunSuite with Matchers:
+
+  private def parse(pattern: String): Regex = RegexParser.parse(pattern) match
+    case Right(r) => r
+    case Left(err) => fail(s"expected successful parse of /$pattern/, got $err")
+
+  test("parses literal string") {
+    parse("abc") shouldBe Regex.literal("abc")
+  }
+
+  test("parses single literal") {
+    parse("a") shouldBe Regex.lit('a')
+  }
+
+  test("parses dot") {
+    parse(".") shouldBe Regex(CharSet.dotDefault)
+  }
+
+  test("parses character class with range") {
+    parse("[a-z]") shouldBe Regex.range('a', 'z')
+  }
+
+  test("parses negated character class") {
+    parse("[^a-z]") shouldBe Regex(CharSet.range('a', 'z').complement)
+  }
+
+  test("parses character class with multiple ranges") {
+    parse("[a-zA-Z0-9_]") shouldBe Regex(
+      CharSet.normalize(
+        Range('a', 'z'),
+        Range('A', 'Z'),
+        Range('0', '9'),
+        Range('_', '_'),
+      ),
+    )
+  }
+
+  test("parses Kleene star") {
+    parse("a*") shouldBe Regex.lit('a').star
+  }
+
+  test("parses plus quantifier") {
+    val a = Regex.lit('a')
+    parse("a+") shouldBe (a.concat(a.star))
+  }
+
+  test("parses optional quantifier") {
+    parse("a?") shouldBe (Eps | Regex.lit('a'))
+  }
+
+  test("parses bounded repetition {2}") {
+    val a = Regex.lit('a')
+    parse("a{2}") shouldBe (a.concat(a))
+  }
+
+  test("parses unbounded repetition {2,}") {
+    val a = Regex.lit('a')
+    parse("a{2,}") shouldBe (a.concat(a).concat(a.star))
+  }
+
+  test("parses alternation") {
+    parse("a|b") shouldBe (Regex.lit('a') | Regex.lit('b'))
+  }
+
+  test("parses group") {
+    parse("(ab)") shouldBe Regex.literal("ab")
+  }
+
+  test("parses non-capturing group") {
+    parse("(?:ab)") shouldBe Regex.literal("ab")
+  }
+
+  test("parses escapes") {
+    parse("\\.") shouldBe Regex.lit('.')
+    parse("\\*") shouldBe Regex.lit('*')
+    parse("\\\\") shouldBe Regex.lit('\\')
+    parse("\\t") shouldBe Regex.lit('\t')
+    parse("\\n") shouldBe Regex.lit('\n')
+  }
+
+  test("parses \\d shorthand") {
+    parse("\\d") shouldBe Regex.range('0', '9')
+  }
+
+  test("rejects anchors") {
+    RegexParser.parse("^a") shouldBe a[Left[RegexParseError.UnsupportedFeature, ?]]
+    RegexParser.parse("a$") shouldBe a[Left[RegexParseError.UnsupportedFeature, ?]]
+  }
+
+  test("rejects lookahead") {
+    RegexParser.parse("(?=a)") shouldBe a[Left[RegexParseError.UnsupportedFeature, ?]]
+    RegexParser.parse("(?!a)") shouldBe a[Left[RegexParseError.UnsupportedFeature, ?]]
+  }
+
+  test("rejects lookbehind") {
+    RegexParser.parse("(?<=a)") shouldBe a[Left[RegexParseError.UnsupportedFeature, ?]]
+  }
+
+  test("rejects backreferences") {
+    RegexParser.parse("(a)\\1") shouldBe a[Left[RegexParseError.UnsupportedFeature, ?]]
+  }
+
+  test("rejects empty character class") {
+    RegexParser.parse("[]") shouldBe a[Left[RegexParseError.InvalidSyntax, ?]]
+  }
+
+  test("rejects unclosed group") {
+    RegexParser.parse("(abc") shouldBe a[Left[RegexParseError.InvalidSyntax, ?]]
+  }
+
+  test("parses nested groups") {
+    parse("(a(bc))") shouldBe Regex.literal("abc")
+  }
+
+  test("parses alternation inside groups") {
+    parse("(a|b)") shouldBe (Regex.lit('a') | Regex.lit('b'))
+  }
+
+  test("parses quantified group") {
+    val ab = Regex.literal("ab")
+    parse("(ab)+") shouldBe (ab.concat(ab.star))
+  }
+
+  test("parses bounded {n,m} repetition") {
+    parse("a{2,3}") shouldBe Regex.lit('a').repeat(2, 3)
+  }
+
+  test("parses character class with single char") {
+    parse("[a]") shouldBe Regex.lit('a')
+  }
+
+  test("parses character class with mixed escapes") {
+    parse("[\\t\\n ]") shouldBe Regex(
+      CharSet.normalize(
+        Range('\t', '\t'),
+        Range('\n', '\n'),
+        Range(' ', ' '),
+      ),
+    )
+  }
+
+  test("parses \\s and \\w shorthands") {
+    parse("\\s") shouldBe Regex(
+      CharSet.normalize(
+        Range(' ', ' '),
+        Range('\t', '\t'),
+        Range('\n', '\n'),
+        Range(0x0b, 0x0b),
+        Range('\f', '\f'),
+        Range('\r', '\r'),
+      ),
+    )
+    parse("\\w") shouldBe Regex(
+      CharSet.normalize(
+        Range('a', 'z'),
+        Range('A', 'Z'),
+        Range('0', '9'),
+        Range('_', '_'),
+      ),
+    )
+  }
+
+  test("rejects unclosed char class") {
+    RegexParser.parse("[abc") shouldBe a[Left[RegexParseError.InvalidSyntax, ?]]
+  }
+
+  test("rejects unclosed quantifier") {
+    RegexParser.parse("a{2") shouldBe a[Left[RegexParseError.InvalidSyntax, ?]]
+  }
+
+  test("rejects dangling backslash") {
+    RegexParser.parse("a\\") shouldBe a[Left[RegexParseError.InvalidSyntax, ?]]
+  }
+
+  test("rejects trailing input after pattern") {
+    RegexParser.parse("*") shouldBe a[Left[RegexParseError.InvalidSyntax, ?]]
+  }
+
+  test("parses empty pattern as Eps") {
+    parse("") shouldBe Eps
+  }
+
+  test("parses complex realistic pattern") {
+    val idStart = Regex(
+      CharSet.normalize(
+        Range('a', 'z'),
+        Range('A', 'Z'),
+        Range('_', '_'),
+      ),
+    )
+    val idRest = Regex(
+      CharSet.normalize(
+        Range('a', 'z'),
+        Range('A', 'Z'),
+        Range('0', '9'),
+        Range('_', '_'),
+      ),
+    )
+    parse("[a-zA-Z_][a-zA-Z0-9_]*") shouldBe (idStart.concat(idRest.star))
+  }

--- a/test/src/alpaca/internal/lexer/regex/SubsetTest.scala
+++ b/test/src/alpaca/internal/lexer/regex/SubsetTest.scala
@@ -1,0 +1,151 @@
+package alpaca
+package internal
+package lexer
+package regex
+
+import alpaca.internal.lexer.regex.Regex.*
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+final class SubsetTest extends AnyFunSuite with Matchers:
+
+  private def s(pattern: String): Subset = Subset.parse(pattern) match
+    case Right(sub) => sub
+    case Left(err) => fail(s"expected successful parse of /$pattern/, got $err")
+  private def s(r: Regex): Subset = Subset.of(r)
+
+  test("identity: r ⊆ r") {
+    s("a").subset(s("a")) shouldBe true
+    s("[a-z]").subset(s("[a-z]")) shouldBe true
+    s("if").subset(s("if")) shouldBe true
+  }
+
+  test("empty language is subset of anything") {
+    s(Empty).subset(s("a")) shouldBe true
+    s(Empty).subset(s(Empty)) shouldBe true
+  }
+
+  test("nothing nonempty is subset of empty") {
+    s("a").subset(s(Empty)) shouldBe false
+  }
+
+  test("Eps ⊆ a*") {
+    s(Eps).subset(s("a*")) shouldBe true
+  }
+
+  test("strict subset: a ⊆ [a-z]") {
+    s("a").subset(s("[a-z]")) shouldBe true
+    s("[a-z]").subset(s("a")) shouldBe false
+  }
+
+  test("prefix subset via .* extension") {
+    s("if.*").subset(s("i.*")) shouldBe true
+    s("i.*").subset(s("if.*")) shouldBe false
+  }
+
+  test("character class subset") {
+    s("[a-c]").subset(s("[a-z]")) shouldBe true
+    s("[a-z]").subset(s("[a-c]")) shouldBe false
+  }
+
+  test("alternation subset") {
+    s("a").subset(s("a|b")) shouldBe true
+    s("a|b").subset(s("a|b|c")) shouldBe true
+    s("a|b|c").subset(s("a|b")) shouldBe false
+  }
+
+  test("Kleene star relationships") {
+    s("a").subset(s("a*")) shouldBe true
+    s("a*").subset(s(".*")) shouldBe true
+  }
+
+  test("isEmpty detects empty languages") {
+    s(Empty).isEmpty shouldBe true
+    s(Eps).isEmpty shouldBe false
+    s(Regex(CharSet.empty)).isEmpty shouldBe true
+    s("a").isEmpty shouldBe false
+    s(s("a").underlying & s("b").underlying).isEmpty shouldBe true
+    s(s("[a-z]").underlying & s("[A-Z]").underlying).isEmpty shouldBe true
+    s(s("[a-m]").underlying & s("[h-z]").underlying).isEmpty shouldBe false
+  }
+
+  test("complement reverses subset") {
+    val a = s("[a-z]")
+    val notA = s(!a.underlying)
+    a.subset(notA) shouldBe false
+    s(a.underlying & notA.underlying).isEmpty shouldBe true
+  }
+
+  // nullable --------------------------------------------------------------
+
+  test("nullable: Eps and Star are nullable") {
+    s(Eps).nullable shouldBe true
+    s("a*").nullable shouldBe true
+  }
+
+  test("nullable: non-empty literals are not nullable") {
+    s("a").nullable shouldBe false
+    s("abc").nullable shouldBe false
+  }
+
+  test("nullable: Empty is not nullable") {
+    s(Empty).nullable shouldBe false
+  }
+
+  test("nullable: a? is nullable") {
+    s("a?").nullable shouldBe true
+  }
+
+  test("nullable: alternation if any branch is") {
+    s("a|b*").nullable shouldBe true
+    s("a|b").nullable shouldBe false
+  }
+
+  test("nullable: concat requires both nullable") {
+    s("a*b*").nullable shouldBe true
+    s("a*b").nullable shouldBe false
+  }
+
+  // derive ----------------------------------------------------------------
+
+  test("derive of literal 'a' wrt 'a' is Eps") {
+    s("a").derive('a'.toInt).underlying shouldBe Eps
+  }
+
+  test("derive of literal 'a' wrt 'b' is Empty") {
+    s("a").derive('b'.toInt).underlying shouldBe Empty
+  }
+
+  test("derive of 'ab' wrt 'a' yields 'b'") {
+    s("ab").derive('a'.toInt).underlying shouldBe Regex.lit('b')
+  }
+
+  test("derive of 'a*' wrt 'a' is 'a*'") {
+    s("a*").derive('a'.toInt).underlying shouldBe Regex.lit('a').star
+  }
+
+  test("derive of char class") {
+    s("[a-z]").derive('m'.toInt).underlying shouldBe Eps
+    s("[a-z]").derive('A'.toInt).underlying shouldBe Empty
+  }
+
+  // withAnySuffix ---------------------------------------------------------
+
+  test("withAnySuffix accepts prefix matches") {
+    val ext = s("if").withAnySuffix
+    ext.derive('i'.toInt).derive('f'.toInt).nullable shouldBe true
+    ext.derive('i'.toInt).derive('f'.toInt).derive('x'.toInt).nullable shouldBe true
+  }
+
+  test("withAnySuffix used in shadow check") {
+    s("if").withAnySuffix.subset(s("i").withAnySuffix) shouldBe true
+    s("i").withAnySuffix.subset(s("if").withAnySuffix) shouldBe false
+  }
+
+  // parse / of constructors -----------------------------------------------
+
+  test("Subset.parse and Subset.of compose") {
+    s("abc").underlying shouldBe Regex.literal("abc")
+    Subset.of(Eps).underlying shouldBe Eps
+  }


### PR DESCRIPTION
## Summary
Series of optimizations on the internal `TokenMatcher` introduced in the refactor PR. Adds a JMH micro-benchmark and turns the matcher from ~50x slower than `java.util.regex.Pattern` into ~0.6–0.8x (faster) on the same workload.

- New \`RegexMatcherBenchmark\` (JMH) exercising the lexer-style hot loop on a CalcLexer pattern set across 100 / 1000 / 10000 character inputs.
- \`TokenMatcher\` switches from a per-call Brzozowski derivative to a **lazy DFA**: each unique \`Vector[Subset]\` state is interned to an integer ID; transitions are stored in flat \`Array[Int]\` tables indexed by state ID. ASCII fast-path is a 128-slot array; non-ASCII falls back to a \`HashMap\`. After warm-up the hot loop is pure integer array indexing.
- State vector is \`Array[Subset]\` cloned per \`matchAt\` call instead of \`Vector[Subset]\` rebuilt per character.
- Running longest match tracked as two \`Int\`s plus a sentinel rather than \`Option[(priority, end)]\`, killing the per-character \`Some\` / named-tuple / \`Integer.valueOf\` allocations.

## JMH `RegexMatcherBenchmark` (5+5 iters, 1 fork)
| input size | java.regex | TokenMatcher | ratio |
|---|---|---|---|
|   100 |  2.17 us/op |   1.72 us/op | **0.79×** (faster) |
|  1000 |  19.7 us/op |  13.50 us/op | **0.68×** (faster) |
| 10000 |   199 us/op | 118.39 us/op | **0.60×** (faster) |

## End-to-end `AlpacaBenchmark.lex` vs master
8 of 10 scenarios faster (iterative_json 10k −64%, big_grammar 10k −49%, etc.). Lone regression is `recursive_json` (deeply nested, 600 MB at size 10000) — the JIT-compiled NFA in `java.util.regex` wins by ~5× there. Closing that needs compile-time DFA or partition-based transitions (future work).

## Base
Stacks on the refactor PR. Replaces #401 + #402 + #403 + #404 + #405 + #406 with one consolidated PR.

## Test plan
- [x] `./mill jvm.test` passes
- [x] `./mill native.test` passes (252 tests)
- [x] `./mill benchmarks.alpaca.runJmh ... RegexMatcherBenchmark` produces the numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)