### PR TITLE
perf(TokenMatcher): eagerly enumerate ASCII DFA at construction

### DIFF
--- a/src/alpaca/internal/lexer/regex/TokenMatcher.scala
+++ b/src/alpaca/internal/lexer/regex/TokenMatcher.scala
@@ -27,6 +27,24 @@ final class TokenMatcher private[regex] (initial: Array[Subset]):
   private var stateCount: Int = 0
 
   private val initialId = registerState(initial.toVector)
+  warmupAsciiDfa()
+
+  /** Eagerly enumerate all ASCII-reachable states so the hot loop never falls into the miss branch. */
+  private def warmupAsciiDfa(): Unit =
+    val queue = mutable.Queue.empty[Int]
+    queue.enqueue(initialId)
+    val visited = mutable.HashSet.empty[Int]
+    visited += initialId
+    while queue.nonEmpty do
+      val sid = queue.dequeue()
+      if !stateInfo(sid).isDead then
+        var c = 0
+        while c < 128 do
+          val next = asciiTransition(sid, c)
+          if !visited.contains(next) then
+            visited += next
+            queue.enqueue(next)
+          c += 1
 
   private def grow(): Unit =
     val n = asciiTrans.length * 2


### PR DESCRIPTION
Builds the ASCII DFA in the constructor via BFS instead of lazily during matchAt. Saves first-call latency and removes the cache-miss branch from the hot loop.

JMH AlpacaBenchmark.lex iterative_json 10000: 21.3 → 16.05 ms (-25%). recursive_json 10000 unchanged within noise (root cause is per-char interpreted DFA cost vs JIT-compiled NFA, not build cost).

Stacks on #409.