### PR TITLE
Make Resolutions a type class instead of a Parser field

### DIFF
--- a/benchmarks/alpaca/src/MathParser.scala
+++ b/benchmarks/alpaca/src/MathParser.scala
@@ -20,17 +20,17 @@ object MathParser extends Parser:
 
   val root: Rule[Int] = rule { case Expr(v) => v }
 
-  override val resolutions = Set(
-    // multiplication and division are left associative (reduction before shift)
-    production.mul.before(MathLexer.`\\*`, MathLexer.`/`),
-    production.div.before(MathLexer.`\\*`, MathLexer.`/`),
-    // addition and subtraction have lower precedence than multiplication and division
-    production.plus.after(MathLexer.`\\*`, MathLexer.`/`),
-    production.minus.after(MathLexer.`\\*`, MathLexer.`/`),
-    // addition and subtraction are left associative (reduction before shift)
-    production.plus.before(MathLexer.`\\+`, MathLexer.`-`),
-    production.minus.before(MathLexer.`\\+`, MathLexer.`-`),
-  )
+given Resolutions[MathParser.type] = resolutions(
+  // multiplication and division are left associative (reduction before shift)
+  production.mul.before(MathLexer.`\\*`, MathLexer.`/`),
+  production.div.before(MathLexer.`\\*`, MathLexer.`/`),
+  // addition and subtraction have lower precedence than multiplication and division
+  production.plus.after(MathLexer.`\\*`, MathLexer.`/`),
+  production.minus.after(MathLexer.`\\*`, MathLexer.`/`),
+  // addition and subtraction are left associative (reduction before shift)
+  production.plus.before(MathLexer.`\\+`, MathLexer.`-`),
+  production.minus.before(MathLexer.`\\+`, MathLexer.`-`),
+)
 
 @main def mathParserMain(): Unit =
   import java.nio.file.{Files, Paths}

--- a/docs/_docs/conflict-resolution.md
+++ b/docs/_docs/conflict-resolution.md
@@ -7,7 +7,7 @@ The BrainFuck grammar from [Getting Started](getting-started.md) has no conflict
 <details>
 <summary>Under the hood: compile-time resolution</summary>
 
-When you define `override val resolutions = Set(...)`, the Alpaca macro incorporates your precedence declarations into the LR(1) parse table at compile time. Conflicts (`ShiftReduceConflict`, `ReduceReduceConflict`) and cycles (`InconsistentConflictResolution`) are detected and reported as compile errors. At runtime, the resolved table executes deterministically.
+When you define a `given Resolutions[MyParser.type] = resolutions(...)`, the Alpaca macro incorporates your precedence declarations into the LR(1) parse table at compile time. Conflicts (`ShiftReduceConflict`, `ReduceReduceConflict`) and cycles (`InconsistentConflictResolution`) are detected and reported as compile errors. At runtime, the resolved table executes deterministically.
 
 </details>
 
@@ -18,6 +18,30 @@ When you define `override val resolutions = Set(...)`, the Alpaca macro incorpor
 **Reduce/reduce conflict:** two productions can reduce the same token sequence. If `Integer -> Num` and `Float -> Num` are both valid and the parser has `Num` on the stack, it cannot decide which reduction to apply.
 
 Both are detected at compile time. They do not manifest as runtime errors.
+
+## Where resolutions Live
+
+`Resolutions` is a type class, keyed by the parser type: `Resolutions[P <: Parser[?]]`. You provide an instance with `given Resolutions[MyParser.type] = resolutions(...)`, and Alpaca picks it up via implicit search when it builds `MyParser`'s parse table.
+
+Because the `given` refers to `MyParser.type`, it must be declared **after** the full parser object, as a sibling declaration at the same scope -- not as a member inside the object:
+
+```scala sc:nocompile
+import alpaca.*
+
+object CalcParser extends Parser:              // object first, fully defined
+  val Expr: Rule[Int] = rule(
+    "plus" { case (Expr(a), Lexer.PLUS(_), Expr(b)) => a + b },
+    { case Lexer.NUMBER(n) => n.value },
+  )
+  val root = rule:
+    case Expr(e) => e
+
+given Resolutions[CalcParser.type] = resolutions(  // given AFTER
+  production.plus.before(Lexer.PLUS),
+)
+```
+
+`production.name` inside `resolutions(...)` still refers to productions by name without qualification -- it is resolved by the inferred parser type `P`, not by textual scope. Only bare non-terminal references passed to `Production(symbols*)` need to be qualified with the parser object's name (see [The Production(symbols*) Selector](#the-productionsymbols-selector)).
 
 ## Reading the Error Messages
 
@@ -52,6 +76,10 @@ object CalcParser extends Parser:
   )
   val root = rule:
     case Expr(e) => e
+
+given Resolutions[CalcParser.type] = resolutions(
+  production.plus.before(Lexer.PLUS, Lexer.MINUS),
+)
 ```
 
 The name must be a string literal placed immediately before the brace. Not all productions need names -- only those you reference in `resolutions`. Referencing an undefined name produces: _"Production with name 'typo' not found"_.
@@ -70,7 +98,7 @@ Full example for a calculator:
 ```scala sc:nocompile
 import alpaca.*
 
-override val resolutions = Set(
+given Resolutions[CalcParser.type] = resolutions(
   // + and - are left-associative and have equal precedence
   production.plus.before(Lexer.PLUS, Lexer.MINUS),
   production.minus.before(Lexer.PLUS, Lexer.MINUS),
@@ -88,18 +116,18 @@ Reading `production.plus.before(Lexer.PLUS, Lexer.MINUS)`: when the parser has r
 
 ## The Production(symbols*) Selector
 
-For unnamed productions, use `Production(symbols*)` to identify them by their right-hand side:
+For unnamed productions, use `Production(symbols*)` to identify them by their right-hand side. Because `resolutions` is now declared *outside* the parser object (see [Where resolutions Live](#where-resolutions-live) below), non-terminals must be qualified with the parser object's name:
 
 ```scala sc:nocompile
 import alpaca.*
 import alpaca.Production as P
 
-override val resolutions = Set(
-  P(Expr, Lexer.TIMES, Expr).before(Lexer.PLUS, Lexer.MINUS),
+given Resolutions[CalcParser.type] = resolutions(
+  P(CalcParser.Expr, Lexer.TIMES, CalcParser.Expr).before(Lexer.PLUS, Lexer.MINUS),
 )
 ```
 
-Both `production.name` and `Production(symbols*)` can coexist in one `resolutions` set.
+Both `production.name` and `Production(symbols*)` can coexist in one `resolutions(...)` call.
 
 ## Token-Side Resolution
 
@@ -108,7 +136,7 @@ Both `production.name` and `Production(symbols*)` can coexist in one `resolution
 ```scala sc:nocompile
 import alpaca.*
 
-override val resolutions = Set(
+given Resolutions[CalcParser.type] = resolutions(
   Lexer.exp.before(production.uplus, production.uminus),
 )
 ```
@@ -132,26 +160,6 @@ production.assign.after(Lexer.ASSIGN)  // shift first -> right grouping
 ## Conflict Cycle Detection
 
 The compiler detects cycles in the transitive closure of constraints. A cycle (A before B before C before A) is contradictory and produces an `InconsistentConflictResolution` error showing the full cycle path.
-
-## Ordering Constraint
-
-`resolutions` must be the **last val** in the parser object. The macro reads declarations top-to-bottom. If `resolutions` appears before a rule declaration, `production.name` references fail with _"Production with name X not found"_.
-
-```scala sc:nocompile
-import alpaca.*
-
-object CalcParser extends Parser:
-  val Expr: Rule[Int] = rule(           // rules first
-    "plus" { case (Expr(a), Lexer.PLUS(_), Expr(b)) => a + b },
-    { case Lexer.NUMBER(n) => n.value },
-  )
-  val root = rule:                      // root second
-    case Expr(e) => e
-
-  override val resolutions = Set(       // resolutions LAST
-    production.plus.before(Lexer.PLUS),
-  )
-```
 
 ## Best Practices
 

--- a/docs/_docs/cookbook/expression-evaluator.md
+++ b/docs/_docs/cookbook/expression-evaluator.md
@@ -58,24 +58,24 @@ Without conflict resolution, this grammar is ambiguous -- the compiler reports s
 ## Conflict Resolution
 
 ```scala sc:nocompile
-  override val resolutions = Set(
-    // Exponentiation: right-associative, highest binary precedence
-    CalcLexer.exp.before(production.uminus, production.exp, production.times, production.divide),
-    production.exp.before(CalcLexer.`\\*`, CalcLexer.`/`),
+given Resolutions[CalcParser.type] = resolutions(
+  // Exponentiation: right-associative, highest binary precedence
+  CalcLexer.exp.before(production.uminus, production.exp, production.times, production.divide),
+  production.exp.before(CalcLexer.`\\*`, CalcLexer.`/`),
 
-    // Unary minus binds tighter than * /
-    production.uminus.before(CalcLexer.`\\*`, CalcLexer.`/`),
+  // Unary minus binds tighter than * /
+  production.uminus.before(CalcLexer.`\\*`, CalcLexer.`/`),
 
-    // Multiplication/division: left-associative, higher than +/-
-    production.times.before(CalcLexer.`\\*`, CalcLexer.`/`),
-    production.divide.before(CalcLexer.`\\*`, CalcLexer.`/`),
+  // Multiplication/division: left-associative, higher than +/-
+  production.times.before(CalcLexer.`\\*`, CalcLexer.`/`),
+  production.divide.before(CalcLexer.`\\*`, CalcLexer.`/`),
 
-    // Addition/subtraction: left-associative, lowest binary precedence
-    production.plus.after(CalcLexer.`\\*`, CalcLexer.`/`),
-    production.plus.before(CalcLexer.`\\+`, CalcLexer.`-`),
-    production.minus.after(CalcLexer.`\\*`, CalcLexer.`/`),
-    production.minus.before(CalcLexer.`\\+`, CalcLexer.`-`),
-  )
+  // Addition/subtraction: left-associative, lowest binary precedence
+  production.plus.after(CalcLexer.`\\*`, CalcLexer.`/`),
+  production.plus.before(CalcLexer.`\\+`, CalcLexer.`-`),
+  production.minus.after(CalcLexer.`\\*`, CalcLexer.`/`),
+  production.minus.before(CalcLexer.`\\+`, CalcLexer.`-`),
+)
 ```
 
 The precedence hierarchy from highest to lowest: `**` > unary `-` > `*` `/` > `+` `-`.

--- a/docs/_docs/parser.md
+++ b/docs/_docs/parser.md
@@ -85,13 +85,14 @@ val FunctionDef: Rule[BrainAST] = rule:
 Production names can contain hyphens, dots, spaces, or any other character that is not a valid Scala identifier. Access them with backtick quoting in `resolutions`:
 
 ```scala sc:nocompile
-val Expr: Rule[Int] = rule(
-  "left-add" { case (Expr(a), Lexer.PLUS(_), Expr(b)) => a + b },
-  "shift.left" { case (Expr(a), Lexer.SHL(_), Expr(b)) => a << b },
-  "if then" { case (Lexer.IF(_), Expr(c), Lexer.THEN(_), Expr(t)) => if c != 0 then t else 0 },
-)
+object MyParser extends Parser:
+  val Expr: Rule[Int] = rule(
+    "left-add" { case (Expr(a), Lexer.PLUS(_), Expr(b)) => a + b },
+    "shift.left" { case (Expr(a), Lexer.SHL(_), Expr(b)) => a << b },
+    "if then" { case (Lexer.IF(_), Expr(c), Lexer.THEN(_), Expr(t)) => if c != 0 then t else 0 },
+  )
 
-override val resolutions = Set(
+given Resolutions[MyParser.type] = resolutions(
   production.`left-add`.before(Lexer.PLUS),
   production.`shift.left`.before(Lexer.SHL),
   production.`if then`.before(Lexer.THEN),
@@ -193,11 +194,11 @@ object CalcParser extends Parser:
   val root = rule:
     case Expr(e) => e
 
-  override val resolutions = Set(
-    production.plus.before(CalcLexer.PLUS),  // left-associative
-  )
+given Resolutions[CalcParser.type] = resolutions(
+  production.plus.before(CalcLexer.PLUS),  // left-associative
+)
 ```
 
-`resolutions` must be the **last val** in the parser object. See [Conflict Resolution](conflict-resolution.md) for details.
+`Resolutions` is a type class: the `given` must be declared **after** the parser object, as a sibling declaration, not as a member inside it. See [Conflict Resolution](conflict-resolution.md#where-resolutions-live) for details.
 
 See [Parser Context](parser-context.md) for custom state, [Extractors](extractors.md) for all pattern forms, and [Debug Settings](debug-settings.md) for compile-time debugging.

--- a/docs/_docs/theory/conflicts.md
+++ b/docs/_docs/theory/conflicts.md
@@ -71,7 +71,7 @@ A minimal example — declaring left-associativity and precedence for the `plus`
 ```scala sc:nocompile
 import alpaca.*
 
-override val resolutions = Set(
+given Resolutions[CalcParser.type] = resolutions(
   production.plus.before(CalcLexer.PLUS, CalcLexer.MINUS),  // left-associative: reduce + before shifting + or -
   production.plus.after(CalcLexer.TIMES, CalcLexer.DIVIDE), // lower precedence: shift * or / before reducing +
 )
@@ -83,9 +83,9 @@ The complete CalcParser resolution set — including `minus`, `times`, and `div`
 
 Conflicts are detected at compile time when the LR(1) parse table is constructed by the `extends Parser` macro. A conflict causes a compile error (`ShiftReduceConflict` or `ReduceReduceConflict`) — no conflict checking happens at runtime.
 
-When you add `override val resolutions = Set(...)`, the macro incorporates your priority declarations into the table construction and re-checks for consistency. A cycle in your declarations (`InconsistentConflictResolution`) is also reported at compile time.
+When you add a `given Resolutions[MyParser.type] = resolutions(...)`, the macro incorporates your priority declarations into the table construction and re-checks for consistency. A cycle in your declarations (`InconsistentConflictResolution`) is also reported at compile time.
 
-> **Compile-time processing:** Alpaca builds the LR(1) parse table when you define `object MyParser extends Parser`. Any conflict — shift/reduce or reduce/reduce — is reported as a compile error immediately, before your code runs. When you add `override val resolutions = Set(...)`, the macro incorporates your priority declarations into the table construction and re-checks for consistency.
+> **Compile-time processing:** Alpaca builds the LR(1) parse table when you define `object MyParser extends Parser`. Any conflict — shift/reduce or reduce/reduce — is reported as a compile error immediately, before your code runs. When you add a `given Resolutions[MyParser.type] = resolutions(...)`, the macro incorporates your priority declarations into the table construction and re-checks for consistency.
 
 ## Cross-links
 

--- a/docs/_docs/theory/full-example.md
+++ b/docs/_docs/theory/full-example.md
@@ -69,7 +69,7 @@ The parser does not know whether `1 + 2 + 3` should reduce `1 + 2` first (left-a
 
 ## Step 4: Adding Conflict Resolution
 
-Adding `override val resolutions` declares which action wins in each conflict state. The full resolution set for the calculator encodes standard BODMAS precedence (`*` and `/` before `+` and `-`) and left-associativity for all four operators:
+Adding a `given Resolutions[CalcParser.type]` declares which action wins in each conflict state. The full resolution set for the calculator encodes standard BODMAS precedence (`*` and `/` before `+` and `-`) and left-associativity for all four operators. The `given` is declared *after* the parser object, as a sibling declaration at the same scope -- see [Conflict Resolution](../conflict-resolution.md#where-resolutions-live) for why:
 
 ```scala sc:nocompile
 import alpaca.*
@@ -86,16 +86,16 @@ object CalcParser extends Parser:
   val root: Rule[Double] = rule:
     case Expr(v) => v
 
-  override val resolutions = Set(
-    // + and - are left-associative with equal precedence
-    production.plus.before(CalcLexer.PLUS, CalcLexer.MINUS),
-    production.plus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
-    production.minus.before(CalcLexer.PLUS, CalcLexer.MINUS),
-    production.minus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
-    // * and / are left-associative; bind tighter than + and -
-    production.times.before(CalcLexer.TIMES, CalcLexer.DIVIDE, CalcLexer.PLUS, CalcLexer.MINUS),
-    production.div.before(CalcLexer.TIMES, CalcLexer.DIVIDE, CalcLexer.PLUS, CalcLexer.MINUS),
-  )
+given Resolutions[CalcParser.type] = resolutions(
+  // + and - are left-associative with equal precedence
+  production.plus.before(CalcLexer.PLUS, CalcLexer.MINUS),
+  production.plus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
+  production.minus.before(CalcLexer.PLUS, CalcLexer.MINUS),
+  production.minus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
+  // * and / are left-associative; bind tighter than + and -
+  production.times.before(CalcLexer.TIMES, CalcLexer.DIVIDE, CalcLexer.PLUS, CalcLexer.MINUS),
+  production.div.before(CalcLexer.TIMES, CalcLexer.DIVIDE, CalcLexer.PLUS, CalcLexer.MINUS),
+)
 ```
 
 Key decisions in the resolution set:
@@ -168,7 +168,7 @@ Each piece of the CalcParser traces back to a theory concept:
 | `extends Parser` generates LR(1) table | LR parse table construction — see [Why LR?](why-lr.md) |
 | Shift/reduce loop | LR parse mechanics — see [Shift-Reduce Parsing](shift-reduce.md) |
 | `ShiftReduceConflict` compile error | Grammar ambiguity — see [Conflicts & Disambiguation](conflicts.md) |
-| `override val resolutions = Set(...)` | Conflict resolution — see [Conflict Resolution](../conflict-resolution.md) |
+| `given Resolutions[CalcParser.type] = resolutions(...)` | Conflict resolution — see [Conflict Resolution](../conflict-resolution.md) |
 | `case (Expr(a), ...) => a + b` | Semantic actions — see [Semantic Actions](semantic-actions.md) |
 | `parse()` returns `7.0: Double` | Typed results via S-attributed translation |
 

--- a/docs/_docs/theory/operator-precedence.md
+++ b/docs/_docs/theory/operator-precedence.md
@@ -75,14 +75,14 @@ object CalcParser extends Parser:
   val root: Rule[Double] = rule:
     case Expr(e) => e
 
-  override val resolutions = Set(
-    production.times.before(CalcLexer.TIMES, CalcLexer.DIVIDE),
-    production.div.before(CalcLexer.TIMES, CalcLexer.DIVIDE),
-    production.plus.before(CalcLexer.PLUS, CalcLexer.MINUS),
-    production.minus.before(CalcLexer.PLUS, CalcLexer.MINUS),
-    production.plus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
-    production.minus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
-  )
+given Resolutions[CalcParser.type] = resolutions(
+  production.times.before(CalcLexer.TIMES, CalcLexer.DIVIDE),
+  production.div.before(CalcLexer.TIMES, CalcLexer.DIVIDE),
+  production.plus.before(CalcLexer.PLUS, CalcLexer.MINUS),
+  production.minus.before(CalcLexer.PLUS, CalcLexer.MINUS),
+  production.plus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
+  production.minus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
+)
 ```
 
 The grammar is ambiguous, but the resolutions tell the parser exactly how to handle every conflict.
@@ -157,15 +157,15 @@ object ExtendedParser extends Parser:
     // ... other operations
   )
 
-  override val resolutions = Set(
-    // * and / bind tighter than + and -
-    production.mul.before(ExtendedLexer.`*`, ExtendedLexer.`/`),
-    production.div.before(ExtendedLexer.`*`, ExtendedLexer.`/`),
-    production.add.before(ExtendedLexer.`+`, ExtendedLexer.`-`),
-    production.sub.before(ExtendedLexer.`+`, ExtendedLexer.`-`),
-    production.add.after(ExtendedLexer.`*`, ExtendedLexer.`/`),
-    production.sub.after(ExtendedLexer.`*`, ExtendedLexer.`/`),
-  )
+given Resolutions[ExtendedParser.type] = resolutions(
+  // * and / bind tighter than + and -
+  production.mul.before(ExtendedLexer.`*`, ExtendedLexer.`/`),
+  production.div.before(ExtendedLexer.`*`, ExtendedLexer.`/`),
+  production.add.before(ExtendedLexer.`+`, ExtendedLexer.`-`),
+  production.sub.before(ExtendedLexer.`+`, ExtendedLexer.`-`),
+  production.add.after(ExtendedLexer.`*`, ExtendedLexer.`/`),
+  production.sub.after(ExtendedLexer.`*`, ExtendedLexer.`/`),
+)
 ```
 
 Without the resolutions, the compiler reports:

--- a/src/alpaca/internal/parser/Parser.scala
+++ b/src/alpaca/internal/parser/Parser.scala
@@ -42,7 +42,6 @@ abstract class Parser[Ctx <: ParserCtx](
    * This is the starting point for parsing.
    */
   val root: Rule[?]
-  
 
   /**
    * Provides access to the parser context within rule definitions.

--- a/src/alpaca/internal/parser/Parser.scala
+++ b/src/alpaca/internal/parser/Parser.scala
@@ -42,33 +42,7 @@ abstract class Parser[Ctx <: ParserCtx](
    * This is the starting point for parsing.
    */
   val root: Rule[?]
-
-  /**
-   * The set of conflict resolution rules for this parser.
-   *
-   * Override this to resolve shift/reduce or reduce/reduce conflicts
-   * by specifying precedence relationships between productions and tokens.
-   */
-  val resolutions: Set[ConflictResolution] = Set.empty
-
-  /**
-   * Provides compile-time access to named productions for use in conflict resolution definitions.
-   *
-   * This method allows you to reference productions by their names as defined in your parser.
-   * It is typically used when specifying conflict resolutions, enabling you to refer to productions
-   * in a type-safe and compile-time-checked manner.
-   *
-   * Example usage:
-   * {{{
-   *   override val resolutions = Set(
-   *     production.plus.after(production.times)
-   *   )
-   * }}}
-   *
-   * @note This is a compile-time only feature and should be used within parser definitions.
-   */
-  @compileTimeOnly(ConflictResolutionOnly)
-  transparent inline protected def production: ProductionSelector = ${ productionImpl }
+  
 
   /**
    * Provides access to the parser context within rule definitions.
@@ -150,11 +124,11 @@ private val cachedProductions: mutable.Map[Type[? <: AnyKind], (Type[? <: AnyKin
   mutable.Map.empty
 
 // $COVERAGE-OFF$
-def productionImpl(using quotes: Quotes): Expr[ProductionSelector] = withLog:
+def productionImpl[P <: Parser[?]: Type](using quotes: Quotes): Expr[ProductionSelector] = withLog:
   import quotes.reflect.*
 
-  val parserSymbol = Symbol.spliceOwner.owner.owner
-  val parserTpe = parserSymbol.typeRef
+  val parserTpe = TypeRepr.of[P]
+  val parserSymbol = parserTpe.typeSymbol
 
   logger.trace(show"Generating production selector for $parserSymbol")
 

--- a/src/alpaca/internal/parser/createTables.scala
+++ b/src/alpaca/internal/parser/createTables.scala
@@ -190,7 +190,7 @@ private def createTablesImpl[Ctx <: ParserCtx: Type](
 
       logger.trace("Conflict resolution rules extracted, building conflict resolution table.")
 
-      var givenResolutions: Expr[Resolutions[p] | Null] = '{ (null) }
+      var givenResolutions: Expr[Resolutions[p] | Null] = '{ null }
 
       val resolutionExprs = scala.util
         .Try:

--- a/src/alpaca/internal/parser/createTables.scala
+++ b/src/alpaca/internal/parser/createTables.scala
@@ -255,7 +255,11 @@ private def createTablesImpl[Ctx <: ParserCtx: Type](
           case (production, action) => Expr.ofTuple(Expr(production) -> action)
 
       '{
-        $givenResolutions // to avoid unused implicit warning
+        // referenced only to avoid an unused-implicit warning; kept lazy and never forced,
+        // since eagerly forcing it here (during Tables[Ctx] construction, i.e. during the
+        // parser object's own <init>) would deadlock against `given Resolutions[P]` instances
+        // that refer back to the parser object (e.g. via `Production(MyParser.SomeRule, ...)`)
+        lazy val _ = $givenResolutions
         ($parseTable: ParseTable, ActionTable($actionTable.toMap))
       }
 // $COVERAGE-ON$

--- a/src/alpaca/internal/parser/createTables.scala
+++ b/src/alpaca/internal/parser/createTables.scala
@@ -58,186 +58,204 @@ private def createTablesImpl[Ctx <: ParserCtx: Type](
   val parserSymbol = Symbol.spliceOwner.owner.owner
   val parserTpe = parserSymbol.typeRef
 
-  logger.trace(show"createTablesImpl for: $parserSymbol")
+  parserTpe.asType match
+    case '[type p <: Parser[Ctx]; p] =>
 
-  val ctxSymbol = parserSymbol.methodMember("ctx").head
-  val parserName = parserSymbol.name.stripSuffix("$")
-  val replaceRefs = new ReplaceRefs[quotes.type]
-  val createLambda = new CreateLambda[quotes.type]
-  val parserExtractor = new ParserExtractors[quotes.type, Ctx]
-  import parserExtractor.*
+      logger.trace(show"createTablesImpl for: $parserSymbol")
 
-  def extractEBNF(ruleName: String)
-    : PartialFunction[Expr[Rule[?]], Seq[(production: Production, action: Expr[Action[Ctx]])]] =
-    case '{ rule(${ Varargs(cases) }*) } =>
-      def createAction(binds: Seq[Option[Bind]], rhs: Term) = createLambda[Action[Ctx]]:
-        case (methSym, (ctx: Term) :: (param: Term) :: Nil) =>
-          val paramExpr = param.asExprOf[RevertedArray[Any]]
-          val replacements = (find = ctxSymbol, replace = ctx) ::
-            binds.iterator.zipWithIndex
-              .collect:
-                case (Some(bind), idx) => ((bind.symbol, bind.symbol.typeRef.asType), Expr(idx))
-              .unsafeFlatMap:
-                case ((bind, '[t]), idx) =>
-                  Some((find = bind, replace = '{ $paramExpr($idx).asInstanceOf[t] }.asTerm))
+      val ctxSymbol = parserSymbol.methodMember("ctx").head
+      val parserName = parserSymbol.name.stripSuffix("$")
+      val replaceRefs = new ReplaceRefs[quotes.type]
+      val createLambda = new CreateLambda[quotes.type]
+      val parserExtractor = new ParserExtractors[quotes.type, Ctx]
+      import parserExtractor.*
+
+      def extractEBNF(ruleName: String)
+        : PartialFunction[Expr[Rule[?]], Seq[(production: Production, action: Expr[Action[Ctx]])]] =
+        case '{ rule(${ Varargs(cases) }*) } =>
+          def createAction(binds: Seq[Option[Bind]], rhs: Term) = createLambda[Action[Ctx]]:
+            case (methSym, (ctx: Term) :: (param: Term) :: Nil) =>
+              val paramExpr = param.asExprOf[RevertedArray[Any]]
+              val replacements = (find = ctxSymbol, replace = ctx) ::
+                binds.iterator.zipWithIndex
+                  .collect:
+                    case (Some(bind), idx) => ((bind.symbol, bind.symbol.typeRef.asType), Expr(idx))
+                  .unsafeFlatMap:
+                    case ((bind, '[t]), idx) =>
+                      Some((find = bind, replace = '{ $paramExpr($idx).asInstanceOf[t] }.asTerm))
+                  .toList
+
+              replaceRefs(replacements*).transformTerm(rhs)(methSym)
+
+          val extractProductionName: Function[Expr[ProductionDefinition[?]], (Tree, ValidName | Null)] =
+            case '{ ($name: ValidName).apply($production: ProductionDefinition[?]) } =>
+              production.asTerm -> name.value.orNull
+            case other =>
+              other.asTerm -> null
+
+          cases.iterator
+            .map(extractProductionName)
+            .map:
+              case (Lambda(_, Match(_, List(caseDef))), name) => (caseDef, name)
+              case (l @ Lambda(_, Match(_, _)), _) =>
+                report.errorAndAbort(
+                  """Each production must have exactly one case. Split multiple cases into separate productions:
+                    |  rule(
+                    |    { case (a(x)) => ... },
+                    |    { case (b(y)) => ... }
+                    |  )""".stripMargin,
+                  l.pos,
+                )
+              case (other, _) =>
+                report.errorAndAbort(show"Unexpected production definition: $other", other.pos)
+            .unsafeFlatMap:
+              case (c @ CaseDef(_, Some(_), _), _) =>
+                report.error("Guards are not supported yet", c.pos)
+                None
+              // Tuple1
+              case (CaseDef(skipTypedOrTest(pattern @ Unapply(_, _, List(_))), None, rhs), name) =>
+                val (symbol, bind, others) = extractEBNFAndAction(pattern)
+                (
+                  production = Production.NonEmpty(NonTerminal(ruleName), NEL(symbol), name),
+                  action = createAction(List(bind), rhs),
+                ) :: others
+
+              // TupleN, N > 1
+              case (CaseDef(skipTypedOrTest(Unapply(_, _, patterns)), None, rhs), name) =>
+                val (symbols, binds, others) = patterns.map(extractEBNFAndAction).unzip3(using _.toTuple)
+                (
+                  production = Production.NonEmpty(NonTerminal(ruleName), NEL(symbols.head, symbols.tail*), name),
+                  action = createAction(binds, rhs),
+                ) :: others.flatten
+            .toList
+
+      val rules = parserTpe.typeSymbol.declarations.iterator.collect:
+        case decl if decl.typeRef <:< TypeRepr.of[Rule[?]] => decl.tree // todo: can we avoid .tree?
+
+      logger.trace("Rules extracted, building parse table.")
+
+      val table = rules
+        .unsafeFlatMap:
+          case ValDef(ruleName, _, Some(rhs)) => extractEBNF(ruleName)(rhs.asExprOf[Rule[?]])
+          case DefDef(ruleName, _, _, Some(rhs)) =>
+            extractEBNF(ruleName)(
+              rhs.asExprOf[Rule[?]],
+            ) // todo: or error? https://github.com/halotukozak/alpaca/issues/230
+          case other: ValOrDefDef if other.rhs.isEmpty => report.errorAndAbort("Enable -Yretain-trees compiler flag")
+        .toList
+        .tap: table =>
+          // csv may be not the best format for this due to the commas
+          logger.toFile(show"$parserName/actionTable.dbg.csv", true)(table.toCsv)
+
+      logger.trace("Productions extracted, building conflict resolution table.")
+
+      val productions = table
+        .map(_.production)
+        .tap: table =>
+          logger.toFile(show"$parserName/productions.dbg", true)(table.mkShow("\n"))
+
+      logger.trace("Productions extracted, building parse and action tables.")
+
+      def findProduction(call: Expr[Production]): Production =
+        val productionsByName = productions.iterator
+          .collect:
+            case p if p.name != null => (p.name, p)
+          .toMap
+
+        val productionsByRhs = productions.iterator.map(p => (p.rhs, p)).toMap
+        call match
+          case '{ ($_ : ProductionSelector).selectDynamic(${ Expr(name) }).$asInstanceOf$[i] } =>
+            val decodedName = NameTransformer.decode(name)
+            logger.trace(show"Looking for production with name '$decodedName' (original: '$name')")
+            productionsByName.getOrElse(
+              decodedName,
+              report.errorAndAbort(show"Production with name '$decodedName' not found", call),
+            )
+
+          case '{ alpaca.Production(${ Varargs(rhs) }*) } =>
+            val args = rhs
+              .map[parser.Symbol.NonEmpty]:
+                case '{ type ruleType <: Rule[?]; $_ : ruleType } => NonTerminal(TypeRepr.of[ruleType].termSymbol.name)
+                case '{ type name <: ValidName; $_ : Token[name, ?, ?] } => Terminal(ValidName.from[name])
               .toList
 
-          replaceRefs(replacements*).transformTerm(rhs)(methSym)
+            logger.trace(show"Looking for production with RHS '${args.mkShow(", ")}'")
 
-      val extractProductionName: Function[Expr[ProductionDefinition[?]], (Tree, ValidName | Null)] =
-        case '{ ($name: ValidName).apply($production: ProductionDefinition[?]) } =>
-          production.asTerm -> name.value.orNull
-        case other =>
-          other.asTerm -> null
-
-      cases.iterator
-        .map(extractProductionName)
-        .map:
-          case (Lambda(_, Match(_, List(caseDef))), name) => (caseDef, name)
-          case (l @ Lambda(_, Match(_, _)), _) =>
-            report.errorAndAbort(
-              """Each production must have exactly one case. Split multiple cases into separate productions:
-                |  rule(
-                |    { case (a(x)) => ... },
-                |    { case (b(y)) => ... }
-                |  )""".stripMargin,
-              l.pos,
+            productionsByRhs.getOrElse(
+              NEL.unsafe(args),
+              report.errorAndAbort(show"Production with RHS '${args.mkShow(" ")}' not found", call),
             )
-          case (other, _) =>
-            report.errorAndAbort(show"Unexpected production definition: $other", other.pos)
-        .unsafeFlatMap:
-          case (c @ CaseDef(_, Some(_), _), _) =>
-            report.error("Guards are not supported yet", c.pos)
-            None
-          // Tuple1
-          case (CaseDef(skipTypedOrTest(pattern @ Unapply(_, _, List(_))), None, rhs), name) =>
-            val (symbol, bind, others) = extractEBNFAndAction(pattern)
-            (
-              production = Production.NonEmpty(NonTerminal(ruleName), NEL(symbol), name),
-              action = createAction(List(bind), rhs),
-            ) :: others
 
-          // TupleN, N > 1
-          case (CaseDef(skipTypedOrTest(Unapply(_, _, patterns)), None, rhs), name) =>
-            val (symbols, binds, others) = patterns.map(extractEBNFAndAction).unzip3(using _.toTuple)
-            (
-              production = Production.NonEmpty(NonTerminal(ruleName), NEL(symbols.head, symbols.tail*), name),
-              action = createAction(binds, rhs),
-            ) :: others.flatten
-        .toList
+          case definition => raiseShouldNeverBeCalled(definition)(using () => ???)
 
-  val rules = parserTpe.typeSymbol.declarations.iterator.collect:
-    case decl if decl.typeRef <:< TypeRepr.of[Rule[?]] => decl.tree // todo: can we avoid .tree?
+      logger.trace("Conflict resolution rules extracted, building conflict resolution table.")
 
-  logger.trace("Rules extracted, building parse table.")
+      var givenResolutions: Expr[Resolutions[p] | Null] = '{ (null) }
 
-  val table = rules
-    .unsafeFlatMap:
-      case ValDef(ruleName, _, Some(rhs)) => extractEBNF(ruleName)(rhs.asExprOf[Rule[?]])
-      case DefDef(ruleName, _, _, Some(rhs)) =>
-        extractEBNF(ruleName)(rhs.asExprOf[Rule[?]]) // todo: or error? https://github.com/halotukozak/alpaca/issues/230
-      case other: ValOrDefDef if other.rhs.isEmpty => report.errorAndAbort("Enable -Yretain-trees compiler flag")
-    .toList
-    .tap: table =>
-      // csv may be not the best format for this due to the commas
-      logger.toFile(show"$parserName/actionTable.dbg.csv", true)(table.toCsv)
+      val resolutionExprs = scala.util
+        .Try:
+          Implicits.search(TypeRepr.of[Resolutions[p]]).runtimeChecked match
+            case success: ImplicitSearchSuccess =>
+              val tree = success.tree
+              givenResolutions = tree.asExprOf[Resolutions[p]]
+              tree.symbol.tree
+        .map:
+          case ValDef(_, _, Some(rhs)) =>
+            rhs.asExprOf[Resolutions[p]]
+        .map:
+          case '{ resolutions[p & Parser[?]](${ Varargs(resolutionExprs) }*) } => resolutionExprs
+        .getOrElse(Nil)
 
-  logger.trace("Productions extracted, building conflict resolution table.")
+      def extractKey(expr: Expr[Production | Token[?, ?, ?]]): ConflictKey = expr match
+        case '{ $prod: Production } => ConflictKey(findProduction(prod))
+        case '{ $_ : Token[name, ?, ?] } => ConflictKey(ValidName.from[name])
 
-  val productions = table
-    .map(_.production)
-    .tap: table =>
-      logger.toFile(show"$parserName/productions.dbg", true)(table.mkShow("\n"))
+      logger.trace("Building conflict resolution table.")
 
-  logger.trace("Productions extracted, building parse and action tables.")
+      val conflictResolutionTable = ConflictResolutionTable(
+        resolutionExprs.iterator
+          .unsafeFlatMap:
+            case '{ (ctx: ResolutionCtx[p]) ?=> ($after: Production | Token[?, ?, ?]).after(${ Varargs(befores) }*) } =>
+              befores.map((_, after))
+            case '{ (ctx: ResolutionCtx[p]) ?=>
+                  ($before: Production | Token[?, ?, ?]).before(${ Varargs(afters) }*)
+                } =>
+              afters.map((before, _))
+          .foldLeft(Map.empty[ConflictKey, Set[ConflictKey]]):
+            case (acc, (before, after)) =>
+              acc.updatedWith(extractKey(before)):
+                case Some(set) => Some(set + extractKey(after))
+                case None => Some(Set(extractKey(after))),
+      ).tap: table =>
+        logger.toFile(show"$parserName/conflictResolutions.dbg", true)(table)
+        logger.toFile(show"$parserName/conflictResolutions.mmd", true)(table.toMermaid)
+        table.verifyNoConflicts()
 
-  def findProduction(call: Expr[Production]): Production =
-    val productionsByName = productions.iterator
-      .collect:
-        case p if p.name != null => (p.name, p)
-      .toMap
+      logger.trace("Conflict resolution table built, identifying root production.")
 
-    val productionsByRhs = productions.iterator.map(p => (p.rhs, p)).toMap
-    call match
-      case '{ ($_ : ProductionSelector).selectDynamic(${ Expr(name) }).$asInstanceOf$[i] } =>
-        val decodedName = NameTransformer.decode(name)
-        logger.trace(show"Looking for production with name '$decodedName' (original: '$name')")
-        productionsByName.getOrElse(
-          decodedName,
-          report.errorAndAbort(show"Production with name '$decodedName' not found", call),
-        )
+      val root = table
+        .collectFirst:
+          case (p @ Production.NonEmpty(NonTerminal("root"), _, _), _) => p
+        .getOrElse:
+          report.errorAndAbort(
+            show"No root rule defined in $parserName. Define a root rule: val root: Rule[Any] = rule { ... }",
+          )
 
-      case '{ alpaca.Production(${ Varargs(rhs) }*) } =>
-        val args = rhs
-          .map[parser.Symbol.NonEmpty]:
-            case '{ type ruleType <: Rule[?]; $_ : ruleType } => NonTerminal(TypeRepr.of[ruleType].termSymbol.name)
-            case '{ type name <: ValidName; $_ : Token[name, ?, ?] } => Terminal(ValidName.from[name])
-          .toList
+      logger.trace("Root production identified, generating parse and action tables.")
 
-        logger.trace(show"Looking for production with RHS '${args.mkShow(", ")}'")
+      val parseTable = Expr:
+        ParseTable(
+          Production.NonEmpty(parser.Symbol.Start, NEL(root.lhs)) :: table.map(_.production),
+          conflictResolutionTable,
+        ).tap: parseTable =>
+          logger.toFile(s"$parserName/parseTable.dbg.csv", true)(parseTable.toCsv)
 
-        productionsByRhs.getOrElse(
-          NEL.unsafe(args),
-          report.errorAndAbort(show"Production with RHS '${args.mkShow(" ")}' not found", call),
-        )
+      val actionTable = Expr.ofList:
+        table.map:
+          case (production, action) => Expr.ofTuple(Expr(production) -> action)
 
-      case definition => raiseShouldNeverBeCalled(definition)(using () => ???)
-
-  logger.trace("Conflict resolution rules extracted, building conflict resolution table.")
-
-  val resolutionExprs = scala.util
-    .Try:
-      parserTpe.typeSymbol.declaredField("resolutions").tree
-    .map:
-      case ValDef(_, _, Some(rhs)) => rhs.asExprOf[Set[ConflictResolution]]
-      case DefDef(_, _, _, Some(rhs)) => rhs.asExprOf[Set[ConflictResolution]]
-    .map:
-      case '{ Set.apply(${ Varargs(resolutionExprs) }*) } => resolutionExprs
-    .getOrElse(Nil)
-
-  def extractKey(expr: Expr[Production | Token[?, ?, ?]]): ConflictKey = expr match
-    case '{ $prod: Production } => ConflictKey(findProduction(prod))
-    case '{ $_ : Token[name, ?, ?] } => ConflictKey(ValidName.from[name])
-
-  logger.trace("Building conflict resolution table.")
-
-  val conflictResolutionTable = ConflictResolutionTable(
-    resolutionExprs.iterator
-      .unsafeFlatMap:
-        case '{ ($after: Production | Token[?, ?, ?]).after(${ Varargs(befores) }*) } => befores.map((_, after))
-        case '{ ($before: Production | Token[?, ?, ?]).before(${ Varargs(afters) }*) } => afters.map((before, _))
-      .foldLeft(Map.empty[ConflictKey, Set[ConflictKey]]):
-        case (acc, (before, after)) =>
-          acc.updatedWith(extractKey(before)):
-            case Some(set) => Some(set + extractKey(after))
-            case None => Some(Set(extractKey(after))),
-  ).tap: table =>
-    logger.toFile(show"$parserName/conflictResolutions.dbg", true)(table)
-    logger.toFile(show"$parserName/conflictResolutions.mmd", true)(table.toMermaid)
-    table.verifyNoConflicts()
-
-  logger.trace("Conflict resolution table built, identifying root production.")
-
-  val root = table
-    .collectFirst:
-      case (p @ Production.NonEmpty(NonTerminal("root"), _, _), _) => p
-    .getOrElse:
-      report.errorAndAbort(
-        show"No root rule defined in $parserName. Define a root rule: val root: Rule[Any] = rule { ... }",
-      )
-
-  logger.trace("Root production identified, generating parse and action tables.")
-
-  val parseTable = Expr:
-    ParseTable(
-      Production.NonEmpty(parser.Symbol.Start, NEL(root.lhs)) :: table.map(_.production),
-      conflictResolutionTable,
-    ).tap: parseTable =>
-      logger.toFile(s"$parserName/parseTable.dbg.csv", true)(parseTable.toCsv)
-
-  val actionTable = Expr.ofList:
-    table.map:
-      case (production, action) => Expr.ofTuple(Expr(production) -> action)
-
-  '{ ($parseTable: ParseTable, ActionTable($actionTable.toMap)) }
+      '{
+        $givenResolutions // to avoid unused implicit warning
+        ($parseTable: ParseTable, ActionTable($actionTable.toMap))
+      }
 // $COVERAGE-ON$

--- a/src/alpaca/parser.scala
+++ b/src/alpaca/parser.scala
@@ -9,6 +9,18 @@ import scala.deriving.Mirror
 
 type Parser[Ctx <: ParserCtx] = alpaca.internal.parser.Parser[Ctx]
 
+opaque type Resolutions[P <: Parser[?]] = Set[ConflictResolution]
+
+sealed trait ResolutionCtx[P <: Parser[?]]
+object ResolutionCtx:
+  private val reusable = new ResolutionCtx[Parser[?]] {}
+  private [alpaca] def refl[P <: Parser[?]]: ResolutionCtx[P] = reusable.asInstanceOf[ResolutionCtx[P]]
+def resolutions[P <: Parser[?]](elements: (ResolutionCtx[P] ?=> ConflictResolution)*): Resolutions[P] =
+  elements.map(_.apply(using ResolutionCtx.refl)).toSet
+
+@compileTimeOnly(ConflictResolutionOnly)
+transparent inline protected def production[P <: Parser[?]](using ResolutionCtx[P]): ProductionSelector = ${ productionImpl[P] }
+
 /**
  * Defines a single production in a grammar rule.
  *
@@ -66,7 +78,7 @@ extension (name: String)
    * )
    *
    * // In conflict resolution:
-   * override val resolutions = Set(
+   * given Resoltions[???] = resolutions(
    *   production.sum.after(Lexer.+),
    * )
    * }}}

--- a/src/alpaca/parser.scala
+++ b/src/alpaca/parser.scala
@@ -14,12 +14,14 @@ opaque type Resolutions[P <: Parser[?]] = Set[ConflictResolution]
 sealed trait ResolutionCtx[P <: Parser[?]]
 object ResolutionCtx:
   private val reusable = new ResolutionCtx[Parser[?]] {}
-  private [alpaca] def refl[P <: Parser[?]]: ResolutionCtx[P] = reusable.asInstanceOf[ResolutionCtx[P]]
+  private[alpaca] def refl[P <: Parser[?]]: ResolutionCtx[P] = reusable.asInstanceOf[ResolutionCtx[P]]
 def resolutions[P <: Parser[?]](elements: (ResolutionCtx[P] ?=> ConflictResolution)*): Resolutions[P] =
   elements.map(_.apply(using ResolutionCtx.refl)).toSet
 
 @compileTimeOnly(ConflictResolutionOnly)
-transparent inline protected def production[P <: Parser[?]](using ResolutionCtx[P]): ProductionSelector = ${ productionImpl[P] }
+transparent inline protected def production[P <: Parser[?]](using ResolutionCtx[P]): ProductionSelector = ${
+  productionImpl[P]
+}
 
 /**
  * Defines a single production in a grammar rule.

--- a/test/src/alpaca/ParserApiTest.scala
+++ b/test/src/alpaca/ParserApiTest.scala
@@ -1,7 +1,5 @@
 package alpaca
 
-import Production as P
-
 import alpaca.internal.Copyable
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -66,15 +64,18 @@ final class ParserApiTest extends AnyFunSuite with Matchers:
     val root = rule:
       case Statement(stmt) => stmt
 
-    override val resolutions = Set(
-      P(CalcLexer.MINUS, Expr).before(CalcLexer.DIVIDE, CalcLexer.TIMES, CalcLexer.PLUS, CalcLexer.MINUS),
-      P(Expr, CalcLexer.DIVIDE, Expr).before(CalcLexer.DIVIDE, CalcLexer.TIMES, CalcLexer.PLUS, CalcLexer.MINUS),
-      P(Expr, CalcLexer.TIMES, Expr).before(CalcLexer.DIVIDE, CalcLexer.TIMES, CalcLexer.PLUS, CalcLexer.MINUS),
-      production.plus.before(CalcLexer.PLUS, CalcLexer.MINUS),
-      production.plus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
-      production.minus.before(CalcLexer.PLUS, CalcLexer.MINUS),
-      production.minus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
-    )
+  given Resolutions[CalcApiParser.type] = resolutions(
+    Production(CalcLexer.MINUS, CalcApiParser.Expr)
+      .before(CalcLexer.DIVIDE, CalcLexer.TIMES, CalcLexer.PLUS, CalcLexer.MINUS),
+    Production(CalcApiParser.Expr, CalcLexer.DIVIDE, CalcApiParser.Expr)
+      .before(CalcLexer.DIVIDE, CalcLexer.TIMES, CalcLexer.PLUS, CalcLexer.MINUS),
+    Production(CalcApiParser.Expr, CalcLexer.TIMES, CalcApiParser.Expr)
+      .before(CalcLexer.DIVIDE, CalcLexer.TIMES, CalcLexer.PLUS, CalcLexer.MINUS),
+    production.plus.before(CalcLexer.PLUS, CalcLexer.MINUS),
+    production.plus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
+    production.minus.before(CalcLexer.PLUS, CalcLexer.MINUS),
+    production.minus.after(CalcLexer.TIMES, CalcLexer.DIVIDE),
+  )
 
   test("basic recognition of various tokens and literals") {
     CalcApiParser.parse(CalcLexer.tokenize("a = 3 + 4 * (5 + 6)").lexemes) should matchPattern:

--- a/test/src/alpaca/integration/CompilationTheoryTest.scala
+++ b/test/src/alpaca/integration/CompilationTheoryTest.scala
@@ -144,7 +144,7 @@ final class CompilationTheoryTest extends AnyFunSuite:
       { case CTLexer.`=`(_) => "=" },
     )
 
-    override val resolutions = Set(
+  given Resolutions[ASTPrinterParser.type] = resolutions(
       production.bareIf.after(CTLexer.`else`),
       CTLexer.`'`.before(
         production.uMinus,

--- a/test/src/alpaca/integration/CompilationTheoryTest.scala
+++ b/test/src/alpaca/integration/CompilationTheoryTest.scala
@@ -145,34 +145,34 @@ final class CompilationTheoryTest extends AnyFunSuite:
     )
 
   given Resolutions[ASTPrinterParser.type] = resolutions(
-      production.bareIf.after(CTLexer.`else`),
-      CTLexer.`'`.before(
-        production.uMinus,
-        production.mul,
-        production.div,
-        production.matrixMul,
-        production.matrixDiv,
+    production.bareIf.after(CTLexer.`else`),
+    CTLexer.`'`.before(
+      production.uMinus,
+      production.mul,
+      production.div,
+      production.matrixMul,
+      production.matrixDiv,
+    ),
+    production.uMinus
+      .before(
+        CTLexer.`\\.\\*`,
+        CTLexer.`\\./`,
+        CTLexer.`\\*`,
+        CTLexer.`/`,
       ),
-      production.uMinus
-        .before(
-          CTLexer.`\\.\\*`,
-          CTLexer.`\\./`,
-          CTLexer.`\\*`,
-          CTLexer.`/`,
-        ),
-      production.mul.before(CTLexer.`\\*`, CTLexer.`/`, CTLexer.`\\.\\*`, CTLexer.`\\./`),
-      production.div.before(CTLexer.`\\*`, CTLexer.`/`, CTLexer.`\\.\\*`, CTLexer.`\\./`),
-      production.matrixMul.before(CTLexer.`\\*`, CTLexer.`/`, CTLexer.`\\.\\*`, CTLexer.`\\./`),
-      production.matrixDiv.before(CTLexer.`\\*`, CTLexer.`/`, CTLexer.`\\.\\*`, CTLexer.`\\./`),
-      CTLexer.`\\*`.before(production.add, production.sub, production.matrixAdd, production.matrixSub),
-      CTLexer.`/`.before(production.add, production.sub, production.matrixAdd, production.matrixSub),
-      CTLexer.`\\.\\*`.before(production.add, production.sub, production.matrixAdd, production.matrixSub),
-      CTLexer.`\\./`.before(production.add, production.sub, production.matrixAdd, production.matrixSub),
-      production.add.before(CTLexer.`\\.\\+`, CTLexer.`\\.\\-`, CTLexer.`\\+`, CTLexer.`-`),
-      production.sub.before(CTLexer.`\\.\\+`, CTLexer.`\\.\\-`, CTLexer.`\\+`, CTLexer.`-`),
-      production.matrixAdd.before(CTLexer.`\\.\\+`, CTLexer.`\\.\\-`, CTLexer.`\\+`, CTLexer.`-`),
-      production.matrixSub.before(CTLexer.`\\.\\+`, CTLexer.`\\.\\-`, CTLexer.`\\+`, CTLexer.`-`),
-    )
+    production.mul.before(CTLexer.`\\*`, CTLexer.`/`, CTLexer.`\\.\\*`, CTLexer.`\\./`),
+    production.div.before(CTLexer.`\\*`, CTLexer.`/`, CTLexer.`\\.\\*`, CTLexer.`\\./`),
+    production.matrixMul.before(CTLexer.`\\*`, CTLexer.`/`, CTLexer.`\\.\\*`, CTLexer.`\\./`),
+    production.matrixDiv.before(CTLexer.`\\*`, CTLexer.`/`, CTLexer.`\\.\\*`, CTLexer.`\\./`),
+    CTLexer.`\\*`.before(production.add, production.sub, production.matrixAdd, production.matrixSub),
+    CTLexer.`/`.before(production.add, production.sub, production.matrixAdd, production.matrixSub),
+    CTLexer.`\\.\\*`.before(production.add, production.sub, production.matrixAdd, production.matrixSub),
+    CTLexer.`\\./`.before(production.add, production.sub, production.matrixAdd, production.matrixSub),
+    production.add.before(CTLexer.`\\.\\+`, CTLexer.`\\.\\-`, CTLexer.`\\+`, CTLexer.`-`),
+    production.sub.before(CTLexer.`\\.\\+`, CTLexer.`\\.\\-`, CTLexer.`\\+`, CTLexer.`-`),
+    production.matrixAdd.before(CTLexer.`\\.\\+`, CTLexer.`\\.\\-`, CTLexer.`\\+`, CTLexer.`-`),
+    production.matrixSub.before(CTLexer.`\\.\\+`, CTLexer.`\\.\\-`, CTLexer.`\\+`, CTLexer.`-`),
+  )
 
   test("special functions, initializations") {
     withLazyReader("""

--- a/test/src/alpaca/integration/ExpressionEvaluatorTutorialTest.scala
+++ b/test/src/alpaca/integration/ExpressionEvaluatorTutorialTest.scala
@@ -55,24 +55,24 @@ final class ExpressionEvaluatorTutorialTest extends AnyFunSuite:
       { case CalcLexer.int(n) => n.value.toDouble },
     )
 
-    override val resolutions = Set(
-      // Exponentiation: right-associative, highest binary precedence
-      CalcLexer.exp.before(production.uminus, production.exp, production.times, production.divide),
-      production.exp.before(CalcLexer.`\\*`, CalcLexer.`/`),
+  given Resolutions[ExprEvalParser.type] = resolutions(
+    // Exponentiation: right-associative, highest binary precedence
+    CalcLexer.exp.before(production.uminus, production.exp, production.times, production.divide),
+    production.exp.before(CalcLexer.`\\*`, CalcLexer.`/`),
 
-      // Unary minus binds tighter than * /
-      production.uminus.before(CalcLexer.`\\*`, CalcLexer.`/`),
+    // Unary minus binds tighter than * /
+    production.uminus.before(CalcLexer.`\\*`, CalcLexer.`/`),
 
-      // Multiplication/division: left-associative, higher than +/-
-      production.times.before(CalcLexer.`\\*`, CalcLexer.`/`),
-      production.divide.before(CalcLexer.`\\*`, CalcLexer.`/`),
+    // Multiplication/division: left-associative, higher than +/-
+    production.times.before(CalcLexer.`\\*`, CalcLexer.`/`),
+    production.divide.before(CalcLexer.`\\*`, CalcLexer.`/`),
 
-      // Addition/subtraction: left-associative, lowest binary precedence
-      production.plus.after(CalcLexer.`\\*`, CalcLexer.`/`),
-      production.plus.before(CalcLexer.`\\+`, CalcLexer.`-`),
-      production.minus.after(CalcLexer.`\\*`, CalcLexer.`/`),
-      production.minus.before(CalcLexer.`\\+`, CalcLexer.`-`),
-    )
+    // Addition/subtraction: left-associative, lowest binary precedence
+    production.plus.after(CalcLexer.`\\*`, CalcLexer.`/`),
+    production.plus.before(CalcLexer.`\\+`, CalcLexer.`-`),
+    production.minus.after(CalcLexer.`\\*`, CalcLexer.`/`),
+    production.minus.before(CalcLexer.`\\+`, CalcLexer.`-`),
+  )
 
   test("basic arithmetic") {
     val (_, lexemes) = CalcLexer.tokenize("1 + 2 * 3")

--- a/test/src/alpaca/integration/ExtractorsTutorialTest.scala
+++ b/test/src/alpaca/integration/ExtractorsTutorialTest.scala
@@ -33,9 +33,9 @@ final class ExtractorsTutorialTest extends AnyFunSuite:
         { case MyLexer.NUM(n) => n.value },
       )
 
-      override val resolutions = Set(
-        production.plus.before(MyLexer.`+`),
-      )
+    given Resolutions[TerminalMatchParser.type] = resolutions(
+      production.plus.before(MyLexer.`+`),
+    )
 
     val (_, lexemes) = MyLexer.tokenize("1 + 2 + 3")
     val (_, result) = TerminalMatchParser.parse(lexemes)
@@ -56,9 +56,9 @@ final class ExtractorsTutorialTest extends AnyFunSuite:
       val Stmt: Rule[String] = rule:
         case Expr(e) => s"Expression result: $e"
 
-      override val resolutions = Set(
-        production.plus.before(MyLexer.`+`),
-      )
+    given Resolutions[NonTerminalMatchParser.type] = resolutions(
+      production.plus.before(MyLexer.`+`),
+    )
 
     val (_, lexemes) = MyLexer.tokenize("1 + 2")
     val (_, result) = NonTerminalMatchParser.parse(lexemes)
@@ -178,9 +178,9 @@ final class ExtractorsTutorialTest extends AnyFunSuite:
         { case MyLexer.NUM(n) => n.value },
       )
 
-      override val resolutions = Set(
-        production.times.before(MyLexer.`*`),
-      )
+    given Resolutions[TupleMatchParser.type] = resolutions(
+      production.times.before(MyLexer.`*`),
+    )
 
     val (_, lexemes) = MyLexer.tokenize("(2 * 3)")
     val (_, result) = TupleMatchParser.parse(lexemes)

--- a/test/src/alpaca/integration/MathTest.scala
+++ b/test/src/alpaca/integration/MathTest.scala
@@ -81,28 +81,28 @@ final class MathTest extends AnyFunSuite:
       val root: Rule[Double] = rule:
         case Expr(v) => v
 
-      override val resolutions = Set(
-        CalcLexer.exp.before(
-          production.uplus,
-          production.uminus,
-          production.mod,
-          production.exp,
-          production.fdiv,
-          production.times,
-          production.divide,
-        ),
-        production.exp.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
-        production.uplus.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
-        production.uminus.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
-        production.times.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
-        production.divide.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
-        production.fdiv.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
-        production.mod.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
-        production.plus.after(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
-        production.plus.before(CalcLexer.`\\+`, CalcLexer.`-`),
-        production.minus.after(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
-        production.minus.before(CalcLexer.`\\+`, CalcLexer.`-`),
-      )
+    given Resolutions[MathParser.type] = resolutions(
+      CalcLexer.exp.before(
+        production.uplus,
+        production.uminus,
+        production.mod,
+        production.exp,
+        production.fdiv,
+        production.times,
+        production.divide,
+      ),
+      production.exp.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
+      production.uplus.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
+      production.uminus.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
+      production.times.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
+      production.divide.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
+      production.fdiv.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
+      production.mod.before(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
+      production.plus.after(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
+      production.plus.before(CalcLexer.`\\+`, CalcLexer.`-`),
+      production.minus.after(CalcLexer.`\\*`, CalcLexer.`/`, CalcLexer.fdiv, CalcLexer.`%`),
+      production.minus.before(CalcLexer.`\\+`, CalcLexer.`-`),
+    )
 
     val input = "1 + 2"
     val (_, lexemes) = CalcLexer.tokenize(input)

--- a/test/src/alpaca/integration/ParserActionTest.scala
+++ b/test/src/alpaca/integration/ParserActionTest.scala
@@ -42,9 +42,9 @@ final class ParserActionTest extends AnyFunSuite:
           val result = v * 2
           result
 
-      override val resolutions = Set(
-        production.add.before(BugLexer.`+`),
-      )
+    given Resolutions[MultiActionBug.type] = resolutions(
+      production.add.before(BugLexer.`+`),
+    )
 
     val (_, lexemes) = BugLexer.tokenize("1 + 2")
     val (_, result) = MultiActionBug.parse(lexemes)

--- a/test/src/alpaca/internal/parser/Issue198FixTest.scala
+++ b/test/src/alpaca/internal/parser/Issue198FixTest.scala
@@ -23,9 +23,7 @@ final class Issue198FixTest extends AnyFunSuite with Matchers:
         { case MyLexer.Num(n) => n.value },
       )
 
-      override val resolutions = Set(
-        production.`if-else`.after(MyLexer.Num),
-      )
+    given Resolutions[Issue198Parser.type] = resolutions(production.`if-else`.after(MyLexer.Num))
 
-    assert(Issue198Parser.resolutions.nonEmpty)
+    assert(summon[Resolutions[Issue198Parser.type]].asInstanceOf[Set[?]].nonEmpty)
   }

--- a/test/src/alpaca/internal/parser/ParseTableTest.scala
+++ b/test/src/alpaca/internal/parser/ParseTableTest.scala
@@ -68,7 +68,7 @@ final class ParseTableTest extends AnyFunSuite with Matchers with LoneElement:
       val root = rule:
        case A(a) => a 
 
-      override val resolutions = Set(
+    given Resolutions[CycleParser.type] = resolutions(
         production.A.before(CalcLexer.`+`),
         CalcLexer.`+`.before(P(CalcLexer.`+`)),
         P(CalcLexer.`+`).before(production.A),


### PR DESCRIPTION
## Summary

- **Turn `resolutions` into a type class.** Conflict resolutions no longer live as an overridable `val resolutions: Set[ConflictResolution]` field on `Parser`. Instead, `Resolutions[P <: Parser[?]]` is a standalone opaque type, and you provide an instance with `given Resolutions[MyParser.type] = resolutions(...)`, declared as a sibling *after* the parser object rather than as a member inside it. `Tables[Ctx]` now finds it via `Implicits.search` instead of reading a fixed field off the parser class. `production` moved with it: it's now a top-level `production[P](using ResolutionCtx[P])` rather than a `protected` method on `Parser`.
- **Fix a deadlock the refactor introduced.** The generated `Tables[Ctx]` code kept a live reference to the found `given Resolutions[P]` (just to silence an unused-implicit warning), which forced its evaluation during the parser object's own `<init>`. Whenever the resolutions body refers back to the parser object — e.g. `Production(MyParser.SomeRule, ...)`, the documented style for the `Production(symbols*)` selector — that created a self-referential lazy-val cycle that hung forever (confirmed via thread dump: `ParserApiTest` was stuck 170s+ instead of ~1s). Switched the reference to a `lazy val` so it's still "used" for `-Wunused:all`/`-Werror` but never forced at runtime.
- **Update docs and tests for the new API.** `conflict-resolution.md`, `parser.md`, `cookbook/expression-evaluator.md`, `theory/conflicts.md`, `theory/full-example.md`, and `theory/operator-precedence.md` still described the old `override val resolutions = Set(...)` API; they now show `given Resolutions[MyParser.type] = resolutions(...)`, with non-terminal references passed to `Production(...)` qualified by the parser object's name. Tests (`MathParser`, `ParserApiTest`, `CompilationTheoryTest`, `ExpressionEvaluatorTutorialTest`, `ExtractorsTutorialTest`, `ParserActionTest`, `Issue198FixTest`, `ParseTableTest`) were ported to the new declaration style.

## Test plan
- [x] `./mill compile` — clean, no warnings
- [x] `./mill test` — all 186 tests pass (previously hung indefinitely on `ParserApiTest` before the deadlock fix)