### PR TITLE
chore: drop Scoverage integration from build

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -10,11 +10,10 @@ package build
 import mill.*
 import mill.scalalib.*
 import mill.scalalib.publish.*
-import mill.contrib.scoverage.ScoverageModule
 import mill.contrib.jmh.JmhModule
 import mill.util.VcsVersion
 
-object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPublishModule:
+object `package` extends ScalaModule with SonatypeCentralPublishModule:
   def scalaVersion = "3.8.3-RC1"
 
   def scoverageVersion = "2.5.2"
@@ -92,7 +91,7 @@ object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPu
     mvn"org.slf4j:slf4j-simple:2.0.18",
   )
 
-  object test extends ScalaTests with TestModule.ScalaTest with ScoverageTests:
+  object test extends ScalaTests with TestModule.ScalaTest:
     def scalaTestVersion = "3.2.20"
 
   object benchmarks extends Module:


### PR DESCRIPTION
Removes `ScoverageModule`/`ScoverageTests`. Coverage instrumentation is being retired from the build.

Part 1/7 of splitting a larger rename+refactor into small reviewable PRs (see stack: #chore/disable-wunused-all → ... → refactor/adopt-made-and-erased-tokens, plus an independent docs PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)