### PR TITLE
chore: bump Scala to 3.9.0-RC6

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -15,7 +15,7 @@ import mill.contrib.jmh.JmhModule
 import mill.util.VcsVersion
 
 object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPublishModule:
-  def scalaVersion = "3.8.3-RC1"
+  def scalaVersion = "3.9.0-RC6"
 
   def scoverageVersion = "2.5.2"
 


### PR DESCRIPTION
Prerequisite for the erased-definitions Token rewrite and made/commons adoption in later commits in this stack.

Part 3/7 of the split. Stacked on #434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)