### PR TITLE
chore: enable experimental erased-definitions language feature

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -50,6 +50,7 @@ object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPu
     "--coverage-exclude-files:.*Lexer.*",
     "--coverage-exclude-files:.*createTables.*",
     "-experimental",
+    "-language:experimental.erasedDefinitions",
     "-preview",
     s"-Xmacro-settings:debugDirectory=$moduleDir/debug,enableVerboseNames=true",
     // "-Xmacro-settings:trace=file",


### PR DESCRIPTION
Prerequisite for reimplementing lexer `Token`/`IgnoredToken` as erased classes instead of an opaque type over `Any`.

Part 4/7 of the split. Stacked on #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)