### PR TITLE
chore: disable -Wunused:all compiler flag

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -43,11 +43,10 @@ object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPu
     "-Yshow-suppressed-errors",
     "-Yshow-var-bounds",
     "-Werror",
-    "-Wunused:all",
+//    "-Wunused:all",
     "-experimental",
     "-preview",
     s"-Xmacro-settings:debugDirectory=$moduleDir/debug,enableVerboseNames=true",
-    // "-Xmacro-settings:trace=file",
     //  "-Yprofile-enabled",
     //  s"-Yprofile-trace:$moduleDir/debug/compile-trace.json",
   )


### PR DESCRIPTION
Not actionable against the upcoming rename/refactor yet; disable to keep `-Werror` green.

Replaces #434, which GitHub auto-closed (and won't let me reopen/retarget) after I closed #433 and deleted its now-unwanted branch. Same commit, just targeting `main` directly instead of the removed `chore/drop-scoverage`.

Part 1/6 of the split (Scoverage removal was dropped per feedback — Scoverage stays in the build). Base for #435 (bump-scala-3.9) onward is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)