### PR TITLE
chore: bump Scala to 3.9.0-RC6

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -15,7 +15,7 @@ import mill.contrib.jmh.JmhModule
 import mill.util.VcsVersion
 
 object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPublishModule:
-  def scalaVersion = "3.8.3-RC1"
+  def scalaVersion = "3.9.0-RC6"
 
   def scoverageVersion = "2.5.2"
 
@@ -44,6 +44,11 @@ object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPu
     "-Yshow-var-bounds",
     "-Werror",
     "-Wunused:all",
+    // lexerImpl/createTablesImpl exceed Scoverage's hardcoded instrumentation size limit
+    // under this compiler version (dotty's MaxInstrumentableTreeNodes = 3000 tree nodes,
+    // not configurable); excluded rather than left uninstrumented with a -Werror warning.
+    "--coverage-exclude-files:.*Lexer.*",
+    "--coverage-exclude-files:.*createTables.*",
     "-experimental",
     "-preview",
     s"-Xmacro-settings:debugDirectory=$moduleDir/debug,enableVerboseNames=true",

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -3,9 +3,8 @@ subsection:
   - title: Getting Started
     page: getting-started.md
   - title: Lexer
+    index: lexer.md
     subsection:
-      - title: Lexer
-        page: lexer.md
       - title: Lexer Context
         page: lexer-context.md
       - title: Error Recovery
@@ -13,9 +12,8 @@ subsection:
       - title: Between Stages
         page: on-token-match.md
   - title: Parser
+    index: parser.md
     subsection:
-      - title: Parser
-        page: parser.md
       - title: Parser Context
         page: parser-context.md
       - title: Extractors
@@ -23,13 +21,10 @@ subsection:
       - title: Conflict Resolution
         page: conflict-resolution.md
   - title: Tooling
-    subsection:
-      - title: Debug Settings
-        page: debug-settings.md
+    page: debug-settings.md
   - title: Cookbook
+    index: cookbook/expression-evaluator.md
     subsection:
-      - title: Expression Evaluator
-        page: cookbook/expression-evaluator.md
       - title: JSON Parser
         page: cookbook/json-parser.md
       - title: Contextual Lexing
@@ -37,9 +32,8 @@ subsection:
       - title: BrainFuck Interpreter
         page: cookbook/brainfuck-interpreter.md
   - title: Theory
+    index: theory/pipeline.md
     subsection:
-      - title: The Compilation Pipeline
-        page: theory/pipeline.md
       - title: Tokens and Lexemes
         page: theory/tokens.md
       - title: "The Lexer: Regex to Finite Automata"


### PR DESCRIPTION
Prerequisite for the erased-definitions Token rewrite and made/commons adoption in later commits in this stack.

Replaces #435, which GitHub auto-closed (and won't let me reopen/retarget) after I closed #433/#443 and deleted their now-unwanted branches. Same commit, now targeting `main` directly — the stack no longer routes through a Scoverage-removal or -Wunused:all-disable step (dropped per feedback; -Wunused:all stays enabled the whole way through, see #439 for how that's kept green).

Part 1/5 of the split now (previously 3/7 — Scoverage removal and -Wunused:all disabling were both dropped from the stack per feedback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)