### PR TITLE
chore: add com.halotukozak::made dependency

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -96,6 +96,7 @@ object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPu
     mvn"org.jparsec:jparsec:3.1",
     mvn"org.slf4j:slf4j-api:2.0.18",
     mvn"org.slf4j:slf4j-simple:2.0.18",
+    mvn"com.halotukozak::made::0.4.0",
   )
 
   object test extends ScalaTests with TestModule.ScalaTest with ScoverageTests:


### PR DESCRIPTION
Brings in the `made`/`commons` typeclass-derivation library used by the following `Empty`/`Showable` rewrites.

Replaces #437 (recreated to test whether fresh non-main-base PRs get CI, or whether GitHub simply never triggers CI for PRs targeting a non-default branch on this repo).

Part 3/5 of the split. Stacked on #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)