### PR TITLE
feat: derive Empty via made

### DIFF
--- a/src/halotukozak/alpaca/internal/Empty.scala
+++ b/src/halotukozak/alpaca/internal/Empty.scala
@@ -1,8 +1,12 @@
 package halotukozak
-package alpaca
-package internal
+package alpaca.internal
+
+import halotukozak.commons.containsOnly
 
 import scala.annotation.implicitNotFound
+import halotukozak.made.Made
+import halotukozak.made.MadeFieldElem
+import halotukozak.made.label
 
 /**
  * A type class for creating empty instances of types.
@@ -16,6 +20,16 @@ import scala.annotation.implicitNotFound
 private[alpaca] trait Empty[T] extends (() => T)
 
 private[alpaca] object Empty:
+  inline private def collectDefaults(elems: Tuple)(using elems.type containsOnly MadeFieldElem): Tuple =
+    inline elems match
+      case EmptyTuple => EmptyTuple
+      case _: (head *: tail) =>
+        val head = elems.head.asInstanceOf[head & MadeFieldElem]
+        inline head.default match
+          case _: Null =>
+            compiletime.error("Cannot derive Empty for " + head.label + " because it has no default value.")
+          case default =>
+            default *: collectDefaults(elems.tail.asInstanceOf[tail & Tuple.Tail[elems.type]])
 
   /**
    * Automatically derives an Empty instance for any Product type with default parameters.
@@ -26,51 +40,9 @@ private[alpaca] object Empty:
    * @tparam T the Product type to derive Empty for
    * @return an Empty instance that creates default instances
    */
-  // either way it must be inlined for generic classes
-  inline given derived[T <: Product]: Empty[T] = ${ derivedImpl[T] }
-  // $COVERAGE-OFF$
-
-  private def derivedImpl[T <: Product: Type](using quotes: Quotes): Expr[Empty[T]] = withLog:
-    timeoutOnTooLongCompilation()
-
-    import quotes.reflect.*
-
-    val tpe = TypeRepr.of[T]
-    logger.trace(show"deriving Empty for $tpe")
-
-    val constructor = tpe.classSymbol.get.primaryConstructor
-
-    val defaultParameters = tpe.classSymbol.get.companionClass.methodMembers.iterator
-      .collect:
-        case m if m.name.startsWith("$lessinit$greater$default$") =>
-          m.name.stripPrefix("$lessinit$greater$default$").toInt - 1 -> Ref(m)
-      .toMap
-
-    logger.trace(show"found ${defaultParameters.size} default parameters")
-
-    val parameters = constructor.paramSymss
-      .collect:
-        case params if !params.exists(_.isTypeParam) =>
-          params.iterator.zipWithIndex
-            .map:
-              case (param, idx) if param.flags.is(Flags.HasDefault) =>
-                logger.trace(show"parameter $param has default value")
-                defaultParameters(idx)
-              case (param, _) =>
-                report.errorAndAbort(
-                  show"Cannot derive Empty for ${Type.of[T]}: parameter $param does not have a default value",
-                )
-            .toList
-
-    val value =
-      New(TypeTree.of[T])
-        .select(constructor)
-        .appliedToTypes(tpe.typeArgs)
-        .appliedToArgss(parameters)
-        .asExprOf[T]
-
-    '{
-      new Empty[T]:
-        def apply(): T = $value
-    }
+  inline given derived[T <: Product: Made.Of as m]: Empty[T] = inline m match
+    case m: Made.ProductOf[T] =>
+      () => m.fromTuple(collectDefaults(m.elems).asInstanceOf[m.ElemTypes])
+    case _ =>
+      compiletime.error("Cannot derive Empty for non-Product types.")
 // $COVERAGE-ON$

--- a/test/src/halotukozak/alpaca/internal/EmptyTest.scala
+++ b/test/src/halotukozak/alpaca/internal/EmptyTest.scala
@@ -1,6 +1,7 @@
 package halotukozak
 package alpaca.internal
 
+import halotukozak.alpaca.internal.Empty
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -39,14 +40,14 @@ final class EmptyTest extends AnyFunSuite with Matchers:
 
   test("cannot derive Empty when any parameter lacks a default (compile-time)") {
     """
-      |import halotukozak.alpaca.core.Empty
+      |import alpaca.core.Empty
       |case class Mixed(a: Int, b: String = "b") derives Empty
       |""".stripMargin shouldNot compile
   }
 
   test("cannot derive Empty for non-case classes (compile-time)") {
     """
-      |import halotukozak.alpaca.core.Empty
+      |import alpaca.core.Empty
       |class Regular(val x: Int) derives Empty
       |""".stripMargin shouldNot compile
   }


### PR DESCRIPTION
\`Empty[T]\` now derives via \`halotukozak.made.Made\`/\`MadeFieldElem\` instead of hand-rolled macro plumbing for collecting case-class default values.

Split out of the original combined PR (previously #448) per feedback — this is 2/3 of that split, stacked on #450. All 186 tests pass.

I also tried splitting \`Showable\` (via \`made\`/\`commons\`) out as its own PR, but it turned out inseparable from the Log-removal PR that follows this one: \`Showable\`'s core \`show\` extension used to thread a \`Log\` context parameter through every call, and dropping that is what the \`made\`/\`commons\` adoption actually changed — pulling it out on its own left a bare \`summon[Log]\` with nothing to provide it. It's bundled into the next PR instead, and called out there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)