### PR TITLE
Change Maven groupId from io.github.halotukozak to com.halotukozak

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -86,7 +86,7 @@ object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPu
 
   def pomSettings = PomSettings(
     description = "Another Lexer Parser And Compiler Alpaca",
-    organization = "io.github.halotukozak",
+    organization = "com.halotukozak",
     url = "https://halotukozak.github.io/alpaca/docs/index.html",
     licenses = Seq(License.MIT),
     versionControl = VersionControl.github("halotukozak", "alpaca"),

--- a/docs/_docs/debug-settings.md
+++ b/docs/_docs/debug-settings.md
@@ -53,7 +53,7 @@ object myproject extends ScalaModule {
   def scalaVersion = "3.8.3-RC1"
 
   def mvnDeps = Seq(
-    mvn"io.github.halotukozak::alpaca:0.1.0"
+    mvn"com.halotukozak::alpaca:0.1.0"
   )
 
   override def scalacOptions = Seq(
@@ -83,7 +83,7 @@ Add debug settings to your `build.sbt`:
 ```sbt
 scalaVersion := "3.8.3-RC1"
 
-libraryDependencies += "io.github.halotukozak" %% "alpaca" % "0.1.0"
+libraryDependencies += "com.halotukozak" %% "alpaca" % "0.1.0"
 
 scalacOptions ++= Seq(
   s"-Xmacro-settings:debugDirectory=${baseDirectory.value}/debug",
@@ -109,7 +109,7 @@ Use the `--scala-opt` flag to pass debug settings:
 ```bash
 scala-cli run MyLexer.scala \
   --scala 3.8.3-RC1 \
-  --dep "io.github.halotukozak::alpaca:0.1.0" \
+  --dep "com.halotukozak::alpaca:0.1.0" \
   --scala-opt "-Xmacro-settings:debugDirectory=/absolute/path/to/debug" \
   --scala-opt "-Xmacro-settings:enableVerboseNames=true"
 ```
@@ -118,7 +118,7 @@ Or add directives in your Scala file:
 
 ```scala sc:nocompile
 //> using scala "3.8.3-RC1"
-//> using dep "io.github.halotukozak::alpaca:0.1.0"
+//> using dep "com.halotukozak::alpaca:0.1.0"
 //> using options "-Xmacro-settings:debugDirectory=/absolute/path/to/debug"
 //> using options "-Xmacro-settings:enableVerboseNames=true"
 
@@ -142,7 +142,7 @@ object myparser extends ScalaModule {
   def scalaVersion = "3.8.3-RC1"
 
   def mvnDeps = Seq(
-    mvn"io.github.halotukozak::alpaca:0.1.0"
+    mvn"com.halotukozak::alpaca:0.1.0"
   )
 
   override def scalacOptions = Seq(

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -25,7 +25,7 @@ object brainfuck extends ScalaModule {
   def scalaVersion = "3.8.3-RC1"
   def scalacOptions = Seq("-Yretain-trees")
   def mvnDeps = Seq(
-    mvn"io.github.halotukozak::alpaca:0.1.0"
+    mvn"com.halotukozak::alpaca:0.1.0"
   )
 }
 ```

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -30,7 +30,7 @@ object myproject extends ScalaModule {
   def scalacOptions = Seq("-Yretain-trees")
 
   def mvnDeps = Seq(
-    mvn"io.github.halotukozak::alpaca:0.1.0"
+    mvn"com.halotukozak::alpaca:0.1.0"
   )
 }
 ```
@@ -40,7 +40,7 @@ object myproject extends ScalaModule {
 Add Alpaca to your `build.sbt`:
 
 ```sbt
-libraryDependencies += "io.github.halotukozak" %% "alpaca" % "0.1.0"
+libraryDependencies += "com.halotukozak" %% "alpaca" % "0.1.0"
 ```
 
 Make sure you're using Scala 3.8.3-RC1 or later and enable the required compiler flag:
@@ -56,7 +56,7 @@ Use Alpaca directly in your Scala CLI scripts:
 
 ```scala sc:nocompile
 //> using scala "3.8.3-RC1"
-//> using dep "io.github.halotukozak::alpaca:0.1.0"
+//> using dep "com.halotukozak::alpaca:0.1.0"
 //> using option "-Yretain-trees"
 
 import alpaca.*


### PR DESCRIPTION
Brings alpaca in line with commons/made/mcodec/mrpc/regex, all of which already migrated. alpaca's own package (`src/halotukozak/...`) was already correctly namespaced; only the published Maven coordinate (`pomSettings.organization` in `build.mill`) and install snippets in `docs/` hadn't followed.

Verified locally: `./mill compile` and `./mill mill.scalalib.scalafmt/checkFormatAll` both pass unchanged.

🤖 Generated with Claude Code