### PR TITLE
fix(ci): post compilation-benchmark comments via workflow_run

### DIFF
--- a/.github/workflows/comment-compilation-benchmark.yml
+++ b/.github/workflows/comment-compilation-benchmark.yml
@@ -1,0 +1,83 @@
+name: Comment Compilation Benchmark
+
+on:
+  workflow_run:
+    workflows: ["Test Compilation Benchmark"]
+    types: [completed]
+
+jobs:
+  comment:
+    name: Post Benchmark Comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Download Benchmark Result
+        uses: actions/download-artifact@v4
+        with:
+          name: compilation-benchmark-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upsert PR Comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const result = JSON.parse(fs.readFileSync('benchmark-result.json', 'utf8'));
+
+            const baseMean = result.base_mean;
+            const currMean = result.curr_mean;
+
+            const diff = currMean - baseMean;
+            const perc = (diff / baseMean) * 100;
+
+            const diffAbs = Math.abs(diff).toFixed(3);
+            const percAbs = Math.abs(perc).toFixed(2);
+
+            let status = 'faster';
+            let emoji = '✅';
+            if (perc > 1) {
+              status = 'slower';
+              emoji = '⚠️';
+            } else if (Math.abs(perc) <= 1) {
+              status = 'unchanged';
+              emoji = 'ℹ️';
+            }
+
+            const body = [
+              '### 📊 Test Compilation Benchmark',
+              '',
+              '| Branch | Average Time |',
+              '| :--- | :--- |',
+              `| **Base (${result.base_ref})** | ${baseMean.toFixed(3)}s |`,
+              `| **Current (${result.head_ref})** | ${currMean.toFixed(3)}s |`,
+              '',
+              `**Result:** Current branch is **${diffAbs}s ${status}** (${percAbs}%) ${emoji}`
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: result.pr_number,
+            });
+
+            const botComment = comments.find(c => c.body.includes('### 📊 Test Compilation Benchmark'));
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: result.pr_number,
+                body: body
+              });
+            }

--- a/.github/workflows/test-compilation-benchmark.yml
+++ b/.github/workflows/test-compilation-benchmark.yml
@@ -8,7 +8,6 @@ jobs:
     name: Compilation Benchmark
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       contents: read
 
     steps:
@@ -48,13 +47,13 @@ jobs:
         id: benchmark
         run: |
           set -e
-          
+
           run_bench() {
             local dir=$1
             echo "::group::Benchmarking $dir"
             (
               cd "$dir"
-          
+
               hyperfine --runs 5 --prepare "./mill clean && ./mill compile" "./mill test.compile" --export-json "../${dir}.json"
             )
             echo "::endgroup::"
@@ -69,63 +68,28 @@ jobs:
           echo "base_mean=$(jq '.results[0].mean' base.json)" >> $GITHUB_OUTPUT
           echo "curr_mean=$(jq '.results[0].mean' current.json)" >> $GITHUB_OUTPUT
 
-      - name: Upsert PR Comment
-        uses: actions/github-script@v9
+      # Fork-triggered `pull_request` runs always get a read-only GITHUB_TOKEN,
+      # regardless of the `permissions:` block above, so this job can't post a PR
+      # comment directly (see https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).
+      # Instead it hands the numbers off as an artifact; comment-compilation-benchmark.yml
+      # (triggered by workflow_run, running with the base repo's token) posts the comment.
+      - name: Save Benchmark Result
         env:
           BASE_MEAN: ${{ steps.extract.outputs.base_mean }}
           CURR_MEAN: ${{ steps.extract.outputs.curr_mean }}
+        run: |
+          jq -n \
+            --arg pr_number "${{ github.event.pull_request.number }}" \
+            --arg base_ref "${{ github.event.pull_request.base.ref }}" \
+            --arg head_ref "${{ github.event.pull_request.head.ref }}" \
+            --arg base_mean "$BASE_MEAN" \
+            --arg curr_mean "$CURR_MEAN" \
+            '{pr_number: ($pr_number | tonumber), base_ref: $base_ref, head_ref: $head_ref, base_mean: ($base_mean | tonumber), curr_mean: ($curr_mean | tonumber)}' \
+            > benchmark-result.json
+
+      - name: Upload Benchmark Result
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const baseMean = parseFloat(process.env.BASE_MEAN);
-            const currMean = parseFloat(process.env.CURR_MEAN);
-            
-            const diff = currMean - baseMean;
-            const perc = (diff / baseMean) * 100;
-            
-            const diffAbs = Math.abs(diff).toFixed(3);
-            const percAbs = Math.abs(perc).toFixed(2);
-            
-            let status = 'faster';
-            let emoji = '✅';
-            if (perc > 1) {
-              status = 'slower';
-              emoji = '⚠️';
-            } else if (Math.abs(perc) <= 1) {
-              status = 'unchanged';
-              emoji = 'ℹ️';
-            }
-
-            const body = [
-              '### 📊 Test Compilation Benchmark',
-              '',
-              '| Branch | Average Time |',
-              '| :--- | :--- |',
-              `| **Base (${context.payload.pull_request.base.ref})** | ${baseMean.toFixed(3)}s |`,
-              `| **Current (${context.payload.pull_request.head.ref})** | ${currMean.toFixed(3)}s |`,
-              '',
-              `**Result:** Current branch is **${diffAbs}s ${status}** (${percAbs}%) ${emoji}`
-            ].join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComment = comments.find(c => c.body.includes('### 📊 Test Compilation Benchmark'));
-
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-            }
+          name: compilation-benchmark-result
+          path: benchmark-result.json
+          retention-days: 1


### PR DESCRIPTION
## Summary
- Fork-triggered `pull_request` workflow runs always get a read-only `GITHUB_TOKEN`, regardless of the `permissions:` block — so the "Upsert PR Comment" step in `test-compilation-benchmark.yml` 403'd on every fork-originated PR (e.g. Scala Steward PRs), even though the benchmark itself ran and passed. This was blocking #456 from going green.
- Split the workflow: the `pull_request`-triggered job stays unprivileged and just uploads the benchmark numbers as an artifact; a new `workflow_run`-triggered job (`comment-compilation-benchmark.yml`), which runs with the base repo's token, downloads that artifact and posts/updates the PR comment. Standard secure pattern for commenting on fork PRs.

## Test plan
- [x] Validated both workflow YAML files parse
- [ ] Merge and confirm PR #456's "Compilation Benchmark" check goes green and the comment posts