### PR TITLE
bench: add lexer throughput and error-recovery JMH benchmarks

### DIFF
--- a/benchmarks/alpaca/src/AlpacaBenchmark.scala
+++ b/benchmarks/alpaca/src/AlpacaBenchmark.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit
 import java.nio.file.{Files, Paths}
 import scala.compiletime.uninitialized
 import halotukozak.alpaca.*
+import halotukozak.alpaca.bench.{MathLexer, MathParser}
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/benchmarks/alpaca/src/LexerErrorRecoveryBenchmark.scala
+++ b/benchmarks/alpaca/src/LexerErrorRecoveryBenchmark.scala
@@ -1,0 +1,90 @@
+package bench.alpaca
+
+import halotukozak.alpaca.internal.lexer.ErrorHandling
+import halotukozak.alpaca.{lexer, LexerCtx, Token}
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+import scala.compiletime.uninitialized
+import scala.util.Random
+
+// The strategy is read from a mutable var (set in @Setup from the @Param string below)
+// rather than fixed at compile time, so a single lexer definition can be reused across
+// all four ErrorHandling.Strategy variants.
+private var currentStrategy: ErrorHandling.Strategy = ErrorHandling.Strategy.Stop
+
+private given ErrorHandling[LexerCtx.Default] = _ => currentStrategy
+
+private val ErrorRecoveryLexer = lexer[LexerCtx.Default] {
+  case "\\s+" => Token.Ignored
+  case x @ """[a-zA-Z_][a-zA-Z0-9_]*""" => Token["identifier"](x)
+  case x @ """\d+""" => Token["number"](x.toInt)
+}
+
+private object ErrorRecoveryInputs:
+  // Not matched by ErrorRecoveryLexer's rules, so it always triggers the error path.
+  private val invalidChar = '~'
+
+  private val validUnits = Vector("identifier42", "42", "anotherName", "100", "value7")
+
+  /** Builds an input of roughly `targetSize` chars, with `errorRatePercent`% of positions
+   * replaced by an unmatched character, interspersed between otherwise-valid tokens.
+   */
+  def build(targetSize: Int, errorRatePercent: Int): String =
+    val rnd = Random(seed = 42)
+    val builder = new StringBuilder(targetSize + 32)
+    var i = 0
+    while builder.length < targetSize do
+      if rnd.nextInt(100) < errorRatePercent then builder.append(invalidChar)
+      else builder.append(validUnits(i % validUnits.length))
+      builder.append(' ')
+      i += 1
+    builder.toString
+
+/**
+ * JMH benchmark comparing the cost of each [[ErrorHandling.Strategy]] across different
+ * error rates.
+ *
+ * `Throw` and `Stop` terminate at the first unmatched character, so at any error rate
+ * above 0 they measure "cost to reach and handle the first error" rather than full-input
+ * throughput -- this is intentional, it's the actual cost difference between strategies
+ * this benchmark is meant to surface. `IgnoreChar` and `IgnoreToken` always process the
+ * full input, recovering from every error along the way.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@Fork(1)
+class LexerErrorRecoveryBenchmark:
+
+  @Param(Array("0", "1", "5", "10"))
+  var errorRatePercent: String = uninitialized
+
+  @Param(Array("Throw", "IgnoreChar", "IgnoreToken", "Stop"))
+  var strategyName: String = uninitialized
+
+  @Param(Array("20000"))
+  var size: String = uninitialized
+
+  private var input: String = uninitialized
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    input = ErrorRecoveryInputs.build(size.toInt, errorRatePercent.toInt)
+
+  @Setup(Level.Invocation)
+  def selectStrategy(): Unit =
+    currentStrategy = strategyName match
+      case "Throw" => ErrorHandling.Strategy.Throw(RuntimeException("benchmark error"))
+      case "IgnoreChar" => ErrorHandling.Strategy.IgnoreChar
+      case "IgnoreToken" => ErrorHandling.Strategy.IgnoreToken
+      case "Stop" => ErrorHandling.Strategy.Stop
+      case other => throw IllegalArgumentException(s"Unknown strategy: $other")
+
+  @Benchmark
+  def tokenize(bh: Blackhole): Unit =
+    try bh.consume(ErrorRecoveryLexer.tokenize(input))
+    catch case _: RuntimeException => bh.consume("threw")

--- a/benchmarks/alpaca/src/LexerErrorRecoveryBenchmark.scala
+++ b/benchmarks/alpaca/src/LexerErrorRecoveryBenchmark.scala
@@ -28,7 +28,8 @@ private object ErrorRecoveryInputs:
 
   private val validUnits = Vector("identifier42", "42", "anotherName", "100", "value7")
 
-  /** Builds an input of roughly `targetSize` chars, with `errorRatePercent`% of positions
+  /**
+   * Builds an input of roughly `targetSize` chars, with `errorRatePercent`% of positions
    * replaced by an unmatched character, interspersed between otherwise-valid tokens.
    */
   def build(targetSize: Int, errorRatePercent: Int): String =

--- a/benchmarks/alpaca/src/LexerThroughputBenchmark.scala
+++ b/benchmarks/alpaca/src/LexerThroughputBenchmark.scala
@@ -1,0 +1,80 @@
+package bench.alpaca
+
+import halotukozak.alpaca.{lexer, LexerCtx, Token}
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+import scala.compiletime.uninitialized
+
+// Same token set, defined twice against different context types so the JMH
+// benchmark below can compare tokenization cost with (Default) and without
+// (Empty) line/column tracking overhead.
+private val ThroughputLexerDefault = lexer[LexerCtx.Default] {
+  case "\\s+" => Token.Ignored
+  case x @ ("\\{" | "\\}" | "\\[" | "\\]" | "\\(" | "\\)" | ":" | "," | ";" | "\\." | "\\+" | "-" | "\\*" | "/") =>
+    Token[x.type]
+  case x @ """[a-zA-Z_][a-zA-Z0-9_]*""" => Token["identifier"](x)
+  case x @ """\d+""" => Token["number"](x.toInt)
+}
+
+private val ThroughputLexerEmpty = lexer[LexerCtx.Empty] {
+  case "\\s+" => Token.Ignored
+  case x @ ("\\{" | "\\}" | "\\[" | "\\]" | "\\(" | "\\)" | ":" | "," | ";" | "\\." | "\\+" | "-" | "\\*" | "/") =>
+    Token[x.type]
+  case x @ """[a-zA-Z_][a-zA-Z0-9_]*""" => Token["identifier"](x)
+  case x @ """\d+""" => Token["number"](x.toInt)
+}
+
+private object ThroughputInputs:
+  private val punctuationUnit = "{},:[]();.+-*/ "
+  private val literalUnit = "myIdentifier123 anotherIdentifier 42 someValue100 thirdIdentifier "
+  private val mixedUnit = "{key: value, list: [1, 2, three, four], nested: {inner: 5}}; "
+
+  private def repeatToSize(unit: String, targetSize: Int): String =
+    val builder = new StringBuilder(targetSize + unit.length)
+    while builder.length < targetSize do builder.append(unit)
+    builder.toString
+
+  def forClass(inputClass: String, size: Int): String = inputClass match
+    case "punctuationHeavy" => repeatToSize(punctuationUnit, size)
+    case "literalHeavy" => repeatToSize(literalUnit, size)
+    case "mixed" => repeatToSize(mixedUnit, size)
+    case other => throw IllegalArgumentException(s"Unknown input class: $other")
+
+/**
+ * JMH benchmark isolating lexer throughput across different input shapes and
+ * context types.
+ *
+ * Run with `-prof gc` to track allocations per operation, e.g. in CI nightly:
+ * {{{
+ * ./mill benchmarks.alpaca.runJmh LexerThroughputBenchmark -prof gc
+ * }}}
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@Fork(1)
+class LexerThroughputBenchmark:
+
+  @Param(Array("punctuationHeavy", "literalHeavy", "mixed"))
+  var inputClass: String = uninitialized
+
+  @Param(Array("50000"))
+  var size: String = uninitialized
+
+  private var input: String = uninitialized
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    input = ThroughputInputs.forClass(inputClass, size.toInt)
+
+  @Benchmark
+  def tokenizeDefault(bh: Blackhole): Unit =
+    bh.consume(ThroughputLexerDefault.tokenize(input))
+
+  @Benchmark
+  def tokenizeEmpty(bh: Blackhole): Unit =
+    bh.consume(ThroughputLexerEmpty.tokenize(input))

--- a/benchmarks/alpaca/src/MathParser.scala
+++ b/benchmarks/alpaca/src/MathParser.scala
@@ -1,7 +1,9 @@
-package bench.alpaca
+package halotukozak
+package alpaca
+package bench
 
 import halotukozak.alpaca.internal.parser.Parser
-import halotukozak.alpaca.{lexer, production, resolutions, rule, Resolutions, Rule, Token}
+import halotukozak.alpaca.{lexer, resolutions, rule, Resolutions, Rule, Token}
 
 val MathLexer = lexer {
   case "\\s+" => Token.Ignored

--- a/build.mill
+++ b/build.mill
@@ -129,7 +129,8 @@ object `package` extends Module:
 
     object alpaca extends BenchmarkScalaModule with JmhModule:
       def scalaVersion = build.jvm.scalaVersion()
-      override def scalacOptions = Seq("-experimental", "-preview", "-Yretain-trees")
+      override def scalacOptions =
+        Seq("-experimental", "-preview", "-Yretain-trees", "-language:experimental.erasedDefinitions")
       def moduleDeps = Seq(build.jvm)
 
     object fastparse extends BenchmarkScalaModule:


### PR DESCRIPTION
## Summary

- Adds `LexerThroughputBenchmark` (#463): isolates lexer throughput across three input shapes (punctuationHeavy, literalHeavy, mixed) and two context types (`LexerCtx.Empty`, `LexerCtx.Default`), so line/column tracking overhead is visible separately from raw matching cost. Supports `-prof gc` for alloc/op tracking.
- Adds `LexerErrorRecoveryBenchmark` (#464): parameterized on error rate (0/1/5/10%) and `ErrorHandling.Strategy` (Throw/IgnoreChar/IgnoreToken/Stop), making the cost divergence between "bail on first error" and "recover and keep going" strategies visible.
- Fixes a pre-existing `benchmarks.alpaca` module compile failure (`MathParser.scala` was relying on macro internals only reachable from within `halotukozak.alpaca`'s own package tree; moved it into `halotukozak.alpaca.bench` and added the missing `-language:experimental.erasedDefinitions` flag the module needed since `Token` started extending `compiletime.Erased`). This was blocking the whole module, including these new benchmarks -- filed #470 for the same underlying issue still present (as warnings, not yet errors) in the module's other parser examples.

Both new benchmark classes are picked up automatically by the existing `runtime-benchmark.yml` workflow (`./mill benchmarks.alpaca.runJmh` with no class filter).

## Test plan

- [x] `./mill benchmarks.alpaca.compile` succeeds
- [x] `./mill jvm.test` passes in full
- [x] Smoke-tested both benchmarks with reduced JMH iterations (`-f 1 -wi 1 -i 1`); `LexerThroughputBenchmark` verified with `-prof gc` (reports `gc.alloc.rate`/`gc.alloc.rate.norm`); `LexerErrorRecoveryBenchmark` verified the expected divergence (Throw/Stop bail in ~10-30us at error rate >0%, IgnoreChar/IgnoreToken keep processing the full input in ~3.3-3.9ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)