### PR TITLE
fix(parser): production selector should not be protected

### DIFF
--- a/src/halotukozak/alpaca/parser.scala
+++ b/src/halotukozak/alpaca/parser.scala
@@ -1,9 +1,9 @@
 package halotukozak
 package alpaca
 
-import alpaca.internal.*
-import alpaca.internal.lexer.{Lexeme, Token}
-import alpaca.internal.parser.*
+import halotukozak.alpaca.internal.*
+import halotukozak.alpaca.internal.lexer.{Lexeme, Token}
+import halotukozak.alpaca.internal.parser.*
 
 import scala.annotation.{compileTimeOnly, unused}
 import scala.deriving.Mirror
@@ -20,9 +20,8 @@ def resolutions[P <: parser.Parser[?]](elements: (ResolutionCtx[P] ?=> ConflictR
   elements.map(_.apply(using ResolutionCtx.refl)).toSet
 
 @compileTimeOnly(ConflictResolutionOnly)
-transparent inline def production[P <: parser.Parser[?]](using ResolutionCtx[P]): ProductionSelector = ${
-  productionImpl[P]
-}
+transparent inline def production[P <: parser.Parser[?]](using ResolutionCtx[P]): ProductionSelector =
+  ${ productionImpl[P] }
 
 /**
  * Defines a single production in a grammar rule.

--- a/src/halotukozak/alpaca/parser.scala
+++ b/src/halotukozak/alpaca/parser.scala
@@ -20,7 +20,7 @@ def resolutions[P <: parser.Parser[?]](elements: (ResolutionCtx[P] ?=> ConflictR
   elements.map(_.apply(using ResolutionCtx.refl)).toSet
 
 @compileTimeOnly(ConflictResolutionOnly)
-transparent inline protected def production[P <: parser.Parser[?]](using ResolutionCtx[P]): ProductionSelector = ${
+transparent inline def production[P <: parser.Parser[?]](using ResolutionCtx[P]): ProductionSelector = ${
   productionImpl[P]
 }
 


### PR DESCRIPTION
## Summary
- Closes #477. `production` (used inside `resolutions(production.foo.before(...))` for the documented conflict-resolution DSL) was declared `protected`, scoping it to the `halotukozak.alpaca` package. Since every real downstream consumer's code lives outside that package, the documented `before`/`after` DSL was unusable as written.
- No reason for the restriction: `production` is `@compileTimeOnly` and `transparent inline`, with no runtime existence to protect.
- Confirmed via a doc snippet that `production.plus.before(...)` now resolves with a plain `import halotukozak.alpaca.*` — no `package halotukozak.alpaca` workaround needed.

## Test plan
- [x] `./mill jvm.compile` — builds clean.
- [x] `./mill jvm.test + native.test` — full suite passes.
- [x] `./mill mill.scalalib.scalafmt/checkFormatAll` — clean.
- [x] Verified externally via a scratch doc snippet under a plain import (no package-clause workaround).