### PR TITLE
docs: fix stale imports, versions, and broken links

### DIFF
--- a/docs/_docs/cookbook/brainfuck-interpreter.md
+++ b/docs/_docs/cookbook/brainfuck-interpreter.md
@@ -200,7 +200,7 @@ parsed.result.nn.eval(mem)
 
 ## Testing
 
-Key assertions from the test suite:
+Assertions covering the base eight commands, matching Alpaca's own integration test suite:
 
 ```scala sc-compile-with:brainEval
 // Lexer
@@ -212,7 +212,11 @@ val ast = BrainParser.parse(BrainLexer.tokenize("[>+<-]").lexemes).result
 assert(ast == BrainAST.Root(List(
   BrainAST.While(List(BrainAST.Next, BrainAST.Inc, BrainAST.Prev, BrainAST.Dec))
 )))
+```
 
+The repeat-count, named-cell, and function extensions built up over this guide aren't part of that base test suite -- they're illustrative, and follow from the grammar and evaluator shown above:
+
+```scala sc-compile-with:brainEval
 // Repeat count
 val ast2 = BrainParser.parse(BrainLexer.tokenize("3+").lexemes).result
 assert(ast2 == BrainAST.Root(List(BrainAST.Repeat(3, BrainAST.Inc))))

--- a/docs/_docs/extractors.md
+++ b/docs/_docs/extractors.md
@@ -236,9 +236,8 @@ The user-visible fields are:
 - **`text: String`** — the raw matched characters; always a `String` regardless of token type
 - **`position: Int`** — 1-based column within the current line at match time (post-match; resets on newlines)
 - **`line: Int`** — line number at match time
-- **`fields: Map[String, Any]`** — all context fields at match time, accessible by name
 
-`Lexeme` extends `Selectable`, so field access is type-safe at compile time — `id.position` returns `Int`, not `Any`.
+`Lexeme` extends `Selectable`, so custom context fields captured at match time are also accessible by name, type-safely at compile time — `id.position` returns `Int`, not `Any`. There is no aggregate `fields: Map[String, Any]` accessor; each field is exposed individually through structural selection.
 The type refinement is encoded in the `tokenize()` return type and flows through to the parser.
 
 A concrete example of the snapshot embedded in each lexeme:

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -7,30 +7,30 @@ BrainFuck is a minimal language, but we extend it with repeat counts, named cell
 ## Prerequisites
 
 - JDK 21 or later
-- Mill 1.1.3+ (or SBT — see [Installation](index.md#installation) for SBT/Scala CLI setup)
-- Scala 3.8.3-RC1 or later
+- Mill 1.1.8+ (or SBT — see [Installation](index.md#installation) for SBT/Scala CLI setup)
+- Scala 3.9.0-RC6 or later
 
 ## Project Setup
 
 Create a Mill project with Alpaca as a dependency:
 
 ```mill
-//| mill-version: 1.1.3
+//| mill-version: 1.1.8
 //| mill-jvm-version: 21
 
 import mill._
 import mill.scalalib._
 
 object brainfuck extends ScalaModule {
-  def scalaVersion = "3.8.3-RC1"
-  def scalacOptions = Seq("-Yretain-trees")
+  def scalaVersion = "3.9.0-RC6"
+  def scalacOptions = Seq("-Yretain-trees", "-experimental")
   def mvnDeps = Seq(
-    mvn"com.halotukozak::alpaca:0.1.0"
+    mvn"com.halotukozak::alpaca:0.1.4"
   )
 }
 ```
 
-The `-Yretain-trees` flag is required. Alpaca's macros inspect the AST of your lexer and parser definitions at compile time, and this flag tells the compiler to preserve that information.
+The `-Yretain-trees` flag is required. Alpaca's macros inspect the AST of your lexer and parser definitions at compile time, and this flag tells the compiler to preserve that information. The `-experimental` flag is also required: the lexer/parser macros still touch a couple of `@experimental` compiler APIs internally, and that annotation propagates outward to callers.
 
 ## Step 1: The Lexer
 
@@ -92,7 +92,7 @@ Each `case` maps a regex pattern to a token. `Token["next"]` creates a named tok
 
 Three tokens carry values via the `@` binding:
 - `count @ "[0-9]+"` captures the matched digits, then `Token["repeat"](count.toInt)` converts them to an `Int`.
-- `cell @ "\\$[a-z]+"` captures the full match (including `$`), then `Token["cell"](cell.drop(1))` strips the prefix.
+- `cell @ "\\$[A-Za-z]+"` captures the full match (including `$`), then `Token["cell"](cell.drop(1))` strips the prefix.
 - `name @ "[A-Za-z]+"` captures the function name as-is.
 
 The custom context `BrainLexContext` tracks bracket depth. Inside rule bodies, `ctx` gives access to the context — the lexer increments and decrements counters and uses `require` to catch mismatched brackets at lex time.

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -18,19 +18,19 @@ A type-safe lexer and parser library for Scala 3, featuring compile-time validat
 Add Alpaca as a dependency in your `build.mill`:
 
 ```mill
-//| mill-version: 1.1.3
+//| mill-version: 1.1.8
 //| mill-jvm-version: 21
 
 import mill._
 import mill.scalalib._
 
 object myproject extends ScalaModule {
-  def scalaVersion = "3.8.3-RC1"
+  def scalaVersion = "3.9.0-RC6"
 
-  def scalacOptions = Seq("-Yretain-trees")
+  def scalacOptions = Seq("-Yretain-trees", "-experimental")
 
   def mvnDeps = Seq(
-    mvn"com.halotukozak::alpaca:0.1.0"
+    mvn"com.halotukozak::alpaca:0.1.4"
   )
 }
 ```
@@ -40,14 +40,14 @@ object myproject extends ScalaModule {
 Add Alpaca to your `build.sbt`:
 
 ```sbt
-libraryDependencies += "com.halotukozak" %% "alpaca" % "0.1.0"
+libraryDependencies += "com.halotukozak" %% "alpaca" % "0.1.4"
 ```
 
-Make sure you're using Scala 3.8.3-RC1 or later and enable the required compiler flag:
+Make sure you're using Scala 3.9.0-RC6 or later and enable the required compiler flags:
 
 ```sbt
-scalaVersion := "3.8.3-RC1"
-scalacOptions += "-Yretain-trees"
+scalaVersion := "3.9.0-RC6"
+scalacOptions ++= Seq("-Yretain-trees", "-experimental")
 ```
 
 ### Scala CLI
@@ -55,9 +55,9 @@ scalacOptions += "-Yretain-trees"
 Use Alpaca directly in your Scala CLI scripts:
 
 ```scala
-//> using scala "3.8.3-RC1"
-//> using dep "com.halotukozak::alpaca:0.1.0"
-//> using option "-Yretain-trees"
+//> using scala "3.9.0-RC6"
+//> using dep "com.halotukozak::alpaca:0.1.4"
+//> using options "-Yretain-trees" "-experimental"
 
 import halotukozak.alpaca.*
 
@@ -155,7 +155,7 @@ Runtime benchmarks are **not** run automatically in CI on push or pull requests.
 ### Prerequisites
 
 - JDK 21 or later
-- Mill 1.1.3 or later
+- Mill 1.1.8 or later
 
 ### Build Commands
 

--- a/docs/_docs/lexer-context.md
+++ b/docs/_docs/lexer-context.md
@@ -42,7 +42,7 @@ Position advances by the matched length after each token. The snapshot captures 
 
 `LexerCtx` is the base trait for all lexer contexts. Any custom context must satisfy two rules:
 
-1. **It must be a case class** -- `LexerCtx` has a `this: Product =>` self-type, and the auto-derivation machinery requires a `Product` instance.
+1. **It must be a case class** -- `LexerCtx` extends `Product` directly, and the auto-derivation machinery requires a `Product` instance.
 2. **All fields must have default values** -- The `Empty[T]` derivation macro reads default parameter values from the companion to construct the initial context. If any parameter lacks a default, the macro fails at compile time.
 
 > **Warning:** Do not declare `var text`, `var lastLexeme`, or `var lastRawMatched` in your case class. These fields are provided by the `LexerCtx` trait and managed internally by the lexer. Redeclaring them shadows the internal fields and breaks tokenization.

--- a/docs/_docs/lexer-error-recovery.md
+++ b/docs/_docs/lexer-error-recovery.md
@@ -5,7 +5,7 @@ The Alpaca lexer provides two layers of error feedback: compile-time validation 
 <details>
 <summary>Under the hood: compile-time validation</summary>
 
-The `lexer` macro validates token definitions at compile time. Pattern shadowing (`ShadowException`), invalid regex syntax, and unsupported guards are caught during compilation. The macro performs pairwise regex inclusion checks using the dregex library to ensure every pattern is reachable.
+The `lexer` macro validates token definitions at compile time. Pattern shadowing (`ShadowException`), invalid regex syntax, and unsupported guards are caught during compilation. The macro performs pairwise regex inclusion checks using Alpaca's own `regex` library (`SubsetChecker`) to ensure every pattern is reachable.
 
 </details>
 

--- a/docs/_docs/lexer.md
+++ b/docs/_docs/lexer.md
@@ -12,7 +12,7 @@ import halotukozak.alpaca.*
 The `lexer` block is a Scala 3 macro. At compile time, it:
 
 1. Validates every regex pattern
-2. Checks for overlapping (shadowing) patterns using the [dregex](https://github.com/marianobarrios/dregex) library
+2. Checks for overlapping (shadowing) patterns using Alpaca's own [`regex`](https://github.com/halotukozak/regex) library (`SubsetChecker`, a Brzozowski-derivative DFA emptiness check)
 3. Merges all patterns into a single combined regex with named capture groups
 4. Generates the tokenization loop
 

--- a/docs/_docs/on-token-match.md
+++ b/docs/_docs/on-token-match.md
@@ -155,8 +155,8 @@ Each call to `tokenize()` follows this sequence:
 3. `OnTokenMatch` runs. The default `OnTokenMatch[LexerCtx]` applies any rule-body context changes (`modifyCtx`), derives a snapshot from the context's `Product` elements (case class fields), overrides the snapshot's `text` field with the matched string, and — for `DefinedToken`s — builds a `Lexeme` from the token name, value, and snapshot.
 4. If the matched token is `Token.Ignored` (or a recovery token), `OnTokenMatch` still runs the context modifications and tracking updates but does not emit a `Lexeme`. The token is invisible to the parser.
 5. Tracking hooks (`PositionTracking`, `LineTracking`, custom traits) run as part of the composed `OnTokenMatch`, updating `position`, `line`, etc.
-5. This repeats until the entire input is consumed. `tokenize()` then returns the named tuple `(ctx, lexemes)` -- the final context state and the complete lexeme list.
-6. `parse(lexemes)` receives the list, appends `Lexeme.EOF` internally, and runs the parser grammar against the sequence.
+6. This repeats until the entire input is consumed. `tokenize()` then returns the named tuple `(ctx, lexemes)` -- the final context state and the complete lexeme list.
+7. `parse(lexemes)` receives the list, appends `Lexeme.EOF` internally, and runs the parser grammar against the sequence.
 
 The `Lexeme` list is immutable after `tokenize()` returns. The parser does not alter the lexeme data.
 

--- a/docs/_docs/theory/lexer-fa.md
+++ b/docs/_docs/theory/lexer-fa.md
@@ -92,16 +92,16 @@ string matched by B is also matched by A (that is, L(B) ⊆ L(A), meaning every 
 language is also in A's language), and A appears before B in the lexer definition. If this
 occurs, B will never match — it is dead code.
 
-Alpaca's `RegexChecker` uses the `dregex` library (a Scala/JVM library for decidable regex
-operations) to check at compile time whether any pattern's language is a subset of an earlier
-pattern's language. If shadowing is detected, the macro throws a `ShadowException` with a
-compile error pointing to the offending patterns.
+Alpaca's `SubsetChecker` uses its own `regex` library (a Brzozowski-derivative DFA implementation
+for decidable regex operations) to check at compile time whether any pattern's language is a
+subset of an earlier pattern's language. If shadowing is detected, the macro throws a
+`ShadowException` with a compile error pointing to the offending patterns.
 
 **Example:** If you wrote the integer pattern `"[0-9]+"` before the decimal pattern
 `"[0-9]+(\\.[0-9]+)?"`, the integer pattern would shadow the decimal one — every decimal like
 `"3.14"` is also matched by `"[0-9]+"` up to the decimal point, but more critically the integer
-pattern can match the prefix `"3"` and would consume it first. The `dregex` check catches this
-ordering mistake at compile time rather than silently producing wrong output at runtime.
+pattern can match the prefix `"3"` and would consume it first. The `SubsetChecker` check catches
+this ordering mistake at compile time rather than silently producing wrong output at runtime.
 
 In `CalcLexer`, the decimal pattern `"[0-9]+(\\.[0-9]+)?"` is listed first, before any simpler
 integer-only pattern, so no shadowing occurs.

--- a/src/halotukozak/alpaca/lexer.scala
+++ b/src/halotukozak/alpaca/lexer.scala
@@ -23,7 +23,7 @@ import scala.annotation.{compileTimeOnly, publicInBinary}
  * }
  * }}}
  *
- * @tparam Ctx the global context type, defaults to DefaultGlobalCtx
+ * @tparam Ctx the global context type, defaults to [[LexerCtx.Default]]
  * @param rules the lexer rules as a partial function
  * @param betweenStages implicit OnTokenMatch for context updates
  * @param errorHandling implicit ErrorHandling for custom error recovery
@@ -159,7 +159,7 @@ trait LexerCtx extends Product:
   /**
    * A read-only view of the text still remaining to be tokenized.
    *
-   * Exposed so a custom [[ErrorHandling]] instance can inspect the character(s)
+   * Exposed so a custom [[alpaca.internal.lexer.ErrorHandling]] instance can inspect the character(s)
    * that failed to match any token rule, e.g. to build a diagnostic message
    * such as `unexpected '${ctx.remainingText.charAt(0)}'`.
    */

--- a/src/halotukozak/alpaca/parser.scala
+++ b/src/halotukozak/alpaca/parser.scala
@@ -80,7 +80,7 @@ extension (name: String)
    * )
    *
    * // In conflict resolution:
-   * given Resoltions[???] = resolutions(
+   * given Resolutions[MyParser.type] = resolutions(
    *   production.sum.after(Lexer.+),
    * )
    * }}}
@@ -254,11 +254,11 @@ object ParserCtx:
 extension [Ctx <: ParserCtx](parser: Parser[Ctx])
 
   /**
-   * Parses a list of lexems using the defined grammar.
+   * Parses a list of lexemes using the defined grammar.
    *
    * This is a convenience method that infers the result type from the root rule.
    *
-   * @param lexems the list of lexems to parse
+   * @param lexems the list of lexemes to parse
    * @return a tuple of (context, result), where result may be null on parse failure
    */
   inline def parse(lexems: List[Lexeme[?, ?]]): (


### PR DESCRIPTION
## Summary
`#478` fixed the `import alpaca.*` bug and enabled real snippet compilation for the doc pages, but left a set of prose/comment-only inaccuracies untouched (nothing the compiler would catch):

- Stale install versions (Mill 1.1.3 -> 1.1.8, Scala 3.8.3-RC1 -> 3.9.0-RC6, alpaca 0.1.0 -> 0.1.4) and a missing `-experimental` flag, which consumers currently need alongside `-Yretain-trees`.
- Wrong `dregex` library references in three places -- the actual shadow-detection dependency is Alpaca's own `regex` library (`SubsetChecker`).
- A wrong self-type claim in `lexer-context.md` (`LexerCtx` extends `Product` directly, no self-type).
- A nonexistent `fields: Map[String, Any]` accessor documented in `extractors.md`.
- `brainfuck-interpreter.md`'s "Testing" section attributed untested repeat-count/named-cell assertions to "the test suite" -- the real integration suite only covers the base eight commands.
- A `getting-started.md` prose/code mismatch (`\$[a-z]+` vs the actual `\$[A-Za-z]+` pattern) and a duplicate list number in `on-token-match.md`.
- Scaladoc typos: `Resoltions[???]` -> `Resolutions[MyParser.type]`, `DefaultGlobalCtx` -> `LexerCtx.Default`, and an unqualified `[[ErrorHandling]]` link that scaladoc couldn't resolve.

Rebased on current `main` (picks up #478 and #479); this branch's original `production` accessibility fix landed separately as #479, so it's no longer part of this diff.

## Test plan
- [x] `./mill jvm.test` -- 187/187 passing
- [x] `./mill jvm.docJar` -- clean full rebuild, no real warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)