### PR TITLE
docs: fix spurious 'Recursive value BrainLexer needs type' snippet errors

### DIFF
--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -101,16 +101,9 @@ Pattern order matters: `"\\."` (literal dot — the print command) must appear b
 
 Try it:
 
-<!-- sc:nocompile: this exact snippet (tokenize() + named-tuple destructuring, chained via
-     sc-compile-with) hits a reproducible, filename-tied Scaladoc bug on this page --
-     "Recursive value BrainLexer needs type" -- identical in class to the one filed as
-     halotukozak/alpaca#476 on docs/_docs/on-token-match.md. The identical code compiles fine
-     when chained the same way elsewhere in this file (see Step 5 below) and on other pages
-     (e.g. index.md, cookbook/json-parser.md), so this is a tooling quirk, not a content bug. -->
-
-```scala sc:nocompile
-val (ctx, lexemes) = BrainLexer.tokenize("foo(++)")
-require(ctx.brackets == 0 && ctx.squareBrackets == 0, "Mismatched brackets")
+```scala sc-compile-with:gs-lexer
+val (finalCtx, lexemes) = BrainLexer.tokenize("foo(++)")
+require(finalCtx.brackets == 0 && finalCtx.squareBrackets == 0, "Mismatched brackets")
 println(lexemes.map(_.name))
 // List(functionName, functionOpen, inc, inc, functionClose)
 ```

--- a/docs/_docs/on-token-match.md
+++ b/docs/_docs/on-token-match.md
@@ -7,19 +7,7 @@ The `OnTokenMatch` hook is responsible for advancing the text cursor, constructi
 
 Most programs need nothing more than this:
 
-<!-- The three snippets below that call BrainLexer.tokenize(...) are marked sc:nocompile:
-     Scaladoc's snippet compiler fails with a spurious "Recursive value BrainLexer needs
-     type" error on any snippet on THIS page that destructures a tokenize() call's named-
-     tuple result, even a trivially self-contained one with unique identifier names and no
-     sc-name/sc-compile-with chaining -- moving byte-identical content to a differently-named
-     page compiles cleanly. Snippets on this same page that don't call tokenize() (see the
-     IndentTracking example and the OnTokenMatch type comment further down) compile fine, so
-     this isn't a general problem with this page or with tokenize()/named-tuple destructuring
-     elsewhere in the docs (works on index.md, theory/tokens.md, theory/pipeline.md). It looks
-     tied to this page's filename coinciding with the real `OnTokenMatch` symbol. Tracked as a
-     follow-up rather than blocking #472 on a scaladoc-level bug. -->
-
-```scala sc:nocompile
+```scala sc-name:otm-brainfuck
 import halotukozak.alpaca.*
 
 case class BrainLexContext(
@@ -61,8 +49,10 @@ object BrainParser extends Parser:
     { case BrainLexer.print(_) => BrainAST.Print },
     { case While(whl) => whl },
   )
+```
 
-val (ctx, lexemes) = BrainLexer.tokenize("[>+<-]")
+```scala sc-compile-with:otm-brainfuck
+val (finalCtx, lexemes) = BrainLexer.tokenize("[>+<-]")
 val (_, ast) = BrainParser.parse(lexemes)
 ```
 
@@ -72,12 +62,10 @@ This page explains what is inside those lexemes, how to customize the pipeline, 
 
 The `tokenize()` method returns a named tuple `(ctx: Ctx, lexemes: List[Lexeme])`:
 
-```scala sc:nocompile
-import halotukozak.alpaca.*
+```scala sc-compile-with:otm-brainfuck
+val (finalCtx, lexemes) = BrainLexer.tokenize("++[>+<-].")
 
-val (ctx, lexemes) = BrainLexer.tokenize("++[>+<-].")
-
-// ctx holds the final lexer context state
+// finalCtx holds the final lexer context state
 // lexemes holds the matched tokens (Token.Ignored entries are excluded)
 
 val (_, ast) = BrainParser.parse(lexemes)
@@ -85,13 +73,11 @@ val (_, ast) = BrainParser.parse(lexemes)
 
 The parser accepts `List[Lexeme[?, ?]]` and appends `Lexeme.EOF` internally before processing begins. You do not need to add an end-of-input marker yourself.
 
-The final context (`ctx`) is useful for post-tokenization checks. For example, the BrainFuck lexer tracks bracket depth — after tokenization, you can verify all brackets are balanced:
+The final context (the tuple's `ctx` field) is useful for post-tokenization checks. For example, the BrainFuck lexer tracks bracket depth — after tokenization, you can verify all brackets are balanced:
 
-```scala sc:nocompile
-import halotukozak.alpaca.*
-
-val (ctx, lexemes) = BrainLexer.tokenize("[>+<-]")
-require(ctx.squareBrackets == 0, "Mismatched brackets")
+```scala sc-compile-with:otm-brainfuck
+val (finalCtx, lexemes) = BrainLexer.tokenize("[>+<-]")
+require(finalCtx.squareBrackets == 0, "Mismatched brackets")
 val (_, ast) = BrainParser.parse(lexemes)
 ```
 


### PR DESCRIPTION
## Summary
- Root-causes and fixes #476: the Scaladoc snippet-compiler error wasn't tied to `on-token-match.md`'s filename colliding with the `OnTokenMatch` symbol as originally suspected — it was binding `tokenize()`'s named-tuple `ctx` field to a local `val` also literally named `ctx`, which trips the snippet compiler's typer into a bogus "Recursive value ... needs type" error.
- Renaming the binding (`ctx` -> `finalCtx`) fixes it on both `docs/_docs/on-token-match.md` and the same-class failure that was worked around with `sc:nocompile` in `docs/_docs/getting-started.md`.
- Removes both `sc:nocompile` workarounds and their explanatory comments now that the snippets compile for real.

## Test plan
- [x] `./mill jvm.docJar` completes with `SUCCESS` and no snippet-compiler errors (previously failed with `Recursive value BrainLexer needs type` on both pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)