### PR TITLE
publicly re-export lexer hook types users must reference directly

### DIFF
--- a/docs/_docs/cookbook/contextual-lexing.md
+++ b/docs/_docs/cookbook/contextual-lexing.md
@@ -80,7 +80,6 @@ To get position and line numbers, extend your context with the tracking traits:
 
 ```scala
 import halotukozak.alpaca.*
-import halotukozak.alpaca.internal.lexer.{PositionTracking, LineTracking}
 
 case class BrainLexContext(
   var brackets: Int = 0,
@@ -130,15 +129,11 @@ object BrainParser extends Parser[BrainParserCtx]:
 By default, the lexer throws on unmatched input. You can customize this with an `ErrorHandling` instance:
 
 ```scala sc-compile-with:BrainLexer
-import halotukozak.alpaca.internal.lexer.ErrorHandling
-
 // Option A: skip unrecognized characters silently
 given ErrorHandling[BrainLexContext] = _ => ErrorHandling.Strategy.IgnoreChar
 ```
 
 ```scala sc-compile-with:BrainLexer
-import halotukozak.alpaca.internal.lexer.ErrorHandling
-
 // Option B: stop gracefully, returning what was tokenized so far
 given ErrorHandling[BrainLexContext] = _ => ErrorHandling.Strategy.Stop
 ```

--- a/docs/_docs/lexer-context.md
+++ b/docs/_docs/lexer-context.md
@@ -173,7 +173,6 @@ You can use these traits independently or together. `LexerCtx.Default` extends b
 
 ```scala
 import halotukozak.alpaca.*
-import halotukozak.alpaca.internal.lexer.{PositionTracking, LineTracking}
 
 case class BrainLexContext(
   var squareBrackets: Int = 0,
@@ -205,7 +204,6 @@ Define the `given` in the **trait companion**, not the case class companion. Put
 
 ```scala
 import halotukozak.alpaca.*
-import halotukozak.alpaca.internal.lexer.OnTokenMatch
 
 // Step 1: Trait extending LexerCtx
 trait IndentTracking extends LexerCtx:

--- a/docs/_docs/lexer-error-recovery.md
+++ b/docs/_docs/lexer-error-recovery.md
@@ -112,7 +112,6 @@ You can provide a custom `ErrorHandling` instance for your context type. Four st
 
 ```scala
 import halotukozak.alpaca.*
-import halotukozak.alpaca.internal.lexer.{ErrorHandling, PositionTracking, LineTracking}
 
 case class BrainLexContext(
   var squareBrackets: Int = 0,
@@ -130,7 +129,6 @@ To silently skip unknown characters (useful for BrainFuck where non-command char
 
 ```scala
 import halotukozak.alpaca.*
-import halotukozak.alpaca.internal.lexer.ErrorHandling
 
 // Skip unrecognized characters instead of throwing
 given ErrorHandling[LexerCtx.Default] = _ =>

--- a/docs/_docs/lexer.md
+++ b/docs/_docs/lexer.md
@@ -190,7 +190,6 @@ If the input contains a character that matches no pattern, `tokenize` throws a `
 For large files, use `LazyReader` instead of loading the entire file into a `String`. It reads characters on demand from the underlying file:
 
 ```scala sc-compile-with:BrainLexer
-import halotukozak.alpaca.internal.lexer.LazyReader
 import java.nio.file.Path
 
 val reader = LazyReader.from(Path.of("program.bf"))

--- a/docs/_docs/on-token-match.md
+++ b/docs/_docs/on-token-match.md
@@ -94,7 +94,6 @@ The correct pattern mirrors how Alpaca's built-in `PositionTracking` and `LineTr
 
 ```scala
 import halotukozak.alpaca.*
-import halotukozak.alpaca.internal.lexer.OnTokenMatch
 
 // Step 1: Trait extending LexerCtx
 trait IndentTracking extends LexerCtx:

--- a/src/halotukozak/alpaca/lexer.scala
+++ b/src/halotukozak/alpaca/lexer.scala
@@ -8,6 +8,12 @@ import alpaca.internal.lexer.Token as LexerToken
 import scala.NamedTuple.NamedTuple
 import scala.annotation.{compileTimeOnly, publicInBinary}
 
+/** Public re-exports of lexer types users are expected to reference directly
+ *  (custom `given` instances, tracking traits, large-file tokenization) even
+ *  though they are implemented under `internal.lexer`.
+ */
+export alpaca.internal.lexer.{ErrorHandling, OnTokenMatch, PositionTracking, LineTracking, LazyReader}
+
 /**
  * Creates a lexer from a DSL-based definition.
  *

--- a/src/halotukozak/alpaca/lexer.scala
+++ b/src/halotukozak/alpaca/lexer.scala
@@ -8,11 +8,12 @@ import alpaca.internal.lexer.Token as LexerToken
 import scala.NamedTuple.NamedTuple
 import scala.annotation.{compileTimeOnly, publicInBinary}
 
-/** Public re-exports of lexer types users are expected to reference directly
+/**
+ * Public re-exports of lexer types users are expected to reference directly
  *  (custom `given` instances, tracking traits, large-file tokenization) even
  *  though they are implemented under `internal.lexer`.
  */
-export alpaca.internal.lexer.{ErrorHandling, OnTokenMatch, PositionTracking, LineTracking, LazyReader}
+export alpaca.internal.lexer.{ErrorHandling, LazyReader, LineTracking, OnTokenMatch, PositionTracking}
 
 /**
  * Creates a lexer from a DSL-based definition.


### PR DESCRIPTION
## Summary
- Fixes #474: `ErrorHandling`, `OnTokenMatch`, `PositionTracking`, `LineTracking`, and `LazyReader` are implemented under `internal.lexer`, but they're part of the documented public contract -- users write `given ErrorHandling[Ctx]` / `given OnTokenMatch[Ctx]` instances, extend the tracking traits, and call `LazyReader.from()` themselves. Requiring an import from a package named `internal` for that is misleading API surface.
- Adds `export alpaca.internal.lexer.{ErrorHandling, OnTokenMatch, PositionTracking, LineTracking, LazyReader}` to the top-level `alpaca` package (`lexer.scala`) so these are reachable via `import halotukozak.alpaca.*` like every other public type. The old `internal.lexer`-qualified path still works (nothing moved), this only adds the public one.
- Drops the now-redundant `import halotukozak.alpaca.internal.lexer.{...}` lines from the doc snippets that demonstrated these types.
- Left the rest of `internal.lexer` / all of `internal.parser` untouched -- nothing else there is referenced directly by user-facing code in the docs.

## Test plan
- [x] `./mill jvm.compile` and `./mill native.compile` both `SUCCESS`
- [x] `./mill jvm.test` -- 187/187 SUCCESS, all tests passed
- [x] `./mill jvm.docJar` `SUCCESS` with the internal-package imports removed from the snippets, confirming the public re-export actually works

🤖 Generated with [Claude Code](https://claude.com/claude-code)