### PR TITLE
gitignore: ignore __pycache__/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,6 @@ debug/
 
 benchmarks/inputs/*.txt
 benchmarks/outputs/
+__pycache__/
 
 .planning/


### PR DESCRIPTION
## Summary
- \`benchmarks/sly/__pycache__/\` was showing up as untracked in every \`git status\` (from running the Python sly benchmark harness). Adds \`__pycache__/\` to \`.gitignore\`.
- Found during a pre-1.0.0 repo audit; too trivial to file as its own issue, so fixed directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)