### PR TITLE
perf(parser): stop rebuilding conflict-resolution lookup maps per call

### DIFF
--- a/src/halotukozak/alpaca/internal/parser/createTables.scala
+++ b/src/halotukozak/alpaca/internal/parser/createTables.scala
@@ -41,9 +41,14 @@ private[alpaca] object Tables:
  * 3. Constructs the LR parse table
  * 4. Generates debug output if enabled
  *
- * Note: This implementation uses various collection types (List, Map, etc.).
- * Future optimizations may consider View, Iterator, or Vector to improve
- * compile-time performance and memory usage for large grammars.
+ * Note on collection choices (#466): `table`/`rules`/`productions` are deliberately
+ * materialized to `List` rather than kept lazy (`View`/`Iterator`) because each is traversed
+ * multiple times downstream (productions extraction, root lookup, parse/action table
+ * construction) -- a lazy view would just re-run the macro-tree-walking computation behind it
+ * on every one of those traversals instead of once, a pessimization rather than a speedup.
+ * The actual compile-time cost found here wasn't the collection *type* but a collection being
+ * rebuilt on every call: `findProduction`'s lookup maps were reconstructed from the full
+ * production list on every `.after`/`.before` reference instead of once -- see that function.
  *
  * @tparam Ctx the parser context type
  * @param quotes the Quotes instance
@@ -149,13 +154,18 @@ private def createTablesImpl[Ctx <: ParserCtx: Type](
         .tap: table =>
           logger.toFile(show"$parserName/productions.dbg", true)(table.mkShow("\n"))
 
-      def findProduction(call: Expr[Production]): Production =
-        val productionsByName = productions.iterator
-          .collect:
-            case p if p.name != null => (p.name, p)
-          .toMap
+      // Built once and reused by every findProduction call below, instead of once per call --
+      // findProduction runs once per `.after`/`.before` reference in the grammar's conflict
+      // resolutions, and rebuilding both maps from the full production list on every one of
+      // those calls is wasted work that scales with resolutions × productions for no reason.
+      val productionsByName = productions.iterator
+        .collect:
+          case p if p.name != null => (p.name, p)
+        .toMap
 
-        val productionsByRhs = productions.iterator.map(p => (p.rhs, p)).toMap
+      val productionsByRhs = productions.iterator.map(p => (p.rhs, p)).toMap
+
+      def findProduction(call: Expr[Production]): Production =
         call match
           case '{ ($_ : ProductionSelector).selectDynamic(${ Expr(name) }).$asInstanceOf$[i] } =>
             val decodedName = NameTransformer.decode(name)


### PR DESCRIPTION
## Summary

Fixes #466, which asked to investigate/measure whether switching `createTablesImpl`'s collections to `View`/`Iterator` would help compile-time performance for large grammars -- with the explicit caveat to measure before rewriting.

Measured first, as asked:

- `table`/`rules`/`productions` are traversed **multiple times** downstream (productions extraction, root lookup, parse-table construction, action-table construction). Materializing them as `List` is the correct choice as-is -- `View`/`Iterator` there would re-run the macro-tree-walking computation behind each on every traversal instead of once, a **pessimization**, not a speedup. So the issue's literal suggestion doesn't apply to those.
- The actual cost was somewhere the original comment didn't point at: `findProduction` rebuilt `productionsByName`/`productionsByRhs` from the full production list **from scratch on every call**, and it's called once per `.after`/`.before` reference in the grammar's conflict resolutions -- O(resolutions × productions) for no reason. Hoisted both maps to be built once per macro expansion instead of once per lookup.

## Correctness

`ConflictResolutionTableTest`, `ParserApiTest`, and `ScalaParserTest` (an 884-line real Scala-subset grammar with 64 `.after`/`.before` references -- the actual worst case for this fix) all green, 147/147.

## On the measurement

The existing `benchmarks.alpaca.compile` fixtures don't have enough conflict resolutions to show a signal above noise -- `MathParser.scala` (6 resolutions) moved mean compile time by ~330ms against ~1s stddev across 5 runs, i.e. noise. `BigGrammar.scala` has none. The real payoff is on resolution-heavy grammars like `ScalaParser.scala`, which I wasn't able to isolate into that benchmark module for a clean before/after timing run without risking a long hang (tried copying it in standalone, hit something that pegged CPU near-zero for 40+ minutes with no output -- killed it rather than chase that further, since it's a separate concern from this fix).

Reporting this as-is rather than overstating a number I can't actually back up: the fix is correct and removes a real algorithmic inefficiency (verified by the ScalaParserTest correctness run above touching exactly this code path 64 times), but I don't have a clean isolated timing number for the grammar size where it actually matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)