### PR TITLE
build: upgrade to Scala 3.9.0 final (was 3.9.0-RC6)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -18,7 +18,7 @@ import mill.util.VcsVersion
 object `package` extends Module:
 
   trait Shared extends ScalaModule with PlatformScalaModule with SonatypeCentralPublishModule:
-    def scalaVersion = "3.9.0-RC6"
+    def scalaVersion = "3.9.0"
 
     override def scalacOptions = Seq(
       "-deprecation",
@@ -94,8 +94,8 @@ object `package` extends Module:
     )
 
     def mvnDeps = Seq(
-      mvn"com.halotukozak::regex::0.1.0",
-      mvn"com.halotukozak::made::0.4.0",
+      mvn"com.halotukozak::regex::0.2.0",
+      mvn"com.halotukozak::made::0.4.1",
     )
 
   object jvm extends Shared with ScoverageModule:

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -8,7 +8,7 @@ BrainFuck is a minimal language, but we extend it with repeat counts, named cell
 
 - JDK 21 or later
 - Mill 1.1.8+ (or SBT — see [Installation](index.md#installation) for SBT/Scala CLI setup)
-- Scala 3.9.0-RC6 or later
+- Scala 3.9.0 or later
 
 ## Project Setup
 
@@ -22,7 +22,7 @@ import mill._
 import mill.scalalib._
 
 object brainfuck extends ScalaModule {
-  def scalaVersion = "3.9.0-RC6"
+  def scalaVersion = "3.9.0"
   def scalacOptions = Seq("-Yretain-trees", "-experimental")
   def mvnDeps = Seq(
     mvn"com.halotukozak::alpaca:0.1.4"

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -25,7 +25,7 @@ import mill._
 import mill.scalalib._
 
 object myproject extends ScalaModule {
-  def scalaVersion = "3.9.0-RC6"
+  def scalaVersion = "3.9.0"
 
   def scalacOptions = Seq("-Yretain-trees", "-experimental")
 
@@ -43,10 +43,10 @@ Add Alpaca to your `build.sbt`:
 libraryDependencies += "com.halotukozak" %% "alpaca" % "0.1.4"
 ```
 
-Make sure you're using Scala 3.9.0-RC6 or later and enable the required compiler flags:
+Make sure you're using Scala 3.9.0 or later and enable the required compiler flags:
 
 ```sbt
-scalaVersion := "3.9.0-RC6"
+scalaVersion := "3.9.0"
 scalacOptions ++= Seq("-Yretain-trees", "-experimental")
 ```
 
@@ -55,7 +55,7 @@ scalacOptions ++= Seq("-Yretain-trees", "-experimental")
 Use Alpaca directly in your Scala CLI scripts:
 
 ```scala
-//> using scala "3.9.0-RC6"
+//> using scala "3.9.0"
 //> using dep "com.halotukozak::alpaca:0.1.4"
 //> using options "-Yretain-trees" "-experimental"
 

--- a/src/halotukozak/alpaca/internal/lexer/Tokenization.scala
+++ b/src/halotukozak/alpaca/internal/lexer/Tokenization.scala
@@ -60,11 +60,11 @@ transparent abstract class Tokenization[Ctx <: LexerCtx](
 
     while !globalCtx.text.isEmpty do
       val (token, matched) = matcher.matchAt(globalCtx.text, 0) match
-        case Some((priority, end)) if end > 0 =>
-          val matchedStr = globalCtx.text.subSequence(0, end).toString
+        case m if m != null && m.end > 0 =>
+          val matchedStr = globalCtx.text.subSequence(0, m.end).toString
           globalCtx.lastRawMatched = matchedStr
-          val found = tokensArray(priority)
-          globalCtx.text = globalCtx.text.from(end)
+          val found = tokensArray(m.priority)
+          globalCtx.text = globalCtx.text.from(m.end)
           (found, matchedStr)
 
         case _ =>


### PR DESCRIPTION
## Summary

Fixes #483. Final 3.9.0 shipped, but this wasn't a trivial version-string swap: RC-built TASTy is marked experimental and the final compiler refuses to read it, so alpaca's own macro-touching dependencies had to move first:

1. `com.halotukozak::commons` -> 0.1.2 (first release built against final 3.9.0)
2. `com.halotukozak::regex` -> 0.2.0 and `com.halotukozak::made` -> 0.4.1 (both rebuilt against that commons)
3. alpaca itself, here, now that both are on Maven Central

`regex` 0.2.0 also carries an unrelated-to-this-bump breaking change from #462's fast-path work: `TokenMatcher.matchAt` now returns `(priority: Int, end: Int) | Null` instead of `Option[(priority: Int, end: Int)]`. Updated `Tokenization.scala`'s one call site to match (`findFirst`'s `Option`-returning signature is unchanged, left as-is -- confirmed it's the only other user-facing `matchAt`/`findFirst` caller in the codebase).

## Verification

- `jvm.compile`, `native.compile`: both SUCCESS
- `jvm.test`: 187/187 SUCCESS
- `native.test`: 294/294 SUCCESS
- `mill.scalalib.scalafmt/checkFormatAll`: clean
- `jvm.docJar`: SUCCESS (the RC6-era sidebar.yml `index:`-vs-`page:` scaladoc quirk from the original RC6 bump still holds under final, no doc changes needed beyond the version-string references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)