### PR TITLE
tests.yml: trigger push on main, not master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   pull_request:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
Found while checking branch names across halotukozak-com repos: alpaca's default branch is `main`, but `tests.yml`'s push trigger still said `branches: [ master ]`. Since `master` doesn't exist here, the push trigger never fired — only `pull_request` (unfiltered) did. One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)