### PR TITLE
Docs: fix source-links/revision still pointing at master

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -72,8 +72,8 @@ object `package` extends Module:
         "made with ❤️ and coffee",
         "-social-links:github::https://github.com/halotukozak/alpaca",
         "-snippet-compiler:compile",
-        s"-source-links:$moduleDir=github://halotukozak/alpaca/master",
-        "-revision:master",
+        s"-source-links:$moduleDir=github://halotukozak/alpaca/main",
+        "-revision:main",
       )
     }
 


### PR DESCRIPTION
Default branch was renamed \`master\` -> \`main\` a while back, but \`build.mill\`'s \`scalaDocOptions\` never followed — every "source" link in the published Scaladoc points at the now-deleted \`master\` branch and 404s.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>