### PR TITLE
Make logger.toFile's content parameter by-name

### DIFF
--- a/src/halotukozak/alpaca/internal/logger.scala
+++ b/src/halotukozak/alpaca/internal/logger.scala
@@ -6,10 +6,6 @@ import java.nio.file.{Files, Path}
 import java.util.concurrent.ConcurrentHashMap
 
 private[internal] object logger:
-  // `content` is by-name so the (potentially expensive) Showable rendering at the call site is
-  // only ever forced inside the `foreach` below, i.e. when `ALPACA_DEBUG_DIR` is actually set --
-  // otherwise it would run unconditionally on every macro expansion, debug directory or not.
-  // noinspection AccessorLikeMethodIsUnit
   inline def toFile(path: String, replace: Boolean)(content: => Shown)(using debugSettings: DebugSettings): Unit =
     debugSettings.debugDirectory.foreach: dir =>
       val file = Path.of(dir).resolve(path)

--- a/src/halotukozak/alpaca/internal/logger.scala
+++ b/src/halotukozak/alpaca/internal/logger.scala
@@ -6,8 +6,11 @@ import java.nio.file.{Files, Path}
 import java.util.concurrent.ConcurrentHashMap
 
 private[internal] object logger:
+  // `content` is by-name so the (potentially expensive) Showable rendering at the call site is
+  // only ever forced inside the `foreach` below, i.e. when `ALPACA_DEBUG_DIR` is actually set --
+  // otherwise it would run unconditionally on every macro expansion, debug directory or not.
   // noinspection AccessorLikeMethodIsUnit
-  inline def toFile(path: String, replace: Boolean)(content: Shown)(using debugSettings: DebugSettings): Unit =
+  inline def toFile(path: String, replace: Boolean)(content: => Shown)(using debugSettings: DebugSettings): Unit =
     debugSettings.debugDirectory.foreach: dir =>
       val file = Path.of(dir).resolve(path)
       if replace then this.replace(file)(content) else this.append(file)(content)


### PR DESCRIPTION
## Summary

`table.toCsv` / `table.mkShow` / `table.toMermaid` / `parseTable.toCsv` (all wired through `logger.toFile` in `createTablesImpl`) were being evaluated on every macro expansion regardless of whether `ALPACA_DEBUG_DIR` was set, because `toFile`'s `content` parameter was strict. `toFile` itself already skips the file write via `debugSettings.debugDirectory.foreach`, but that guard did nothing for the eager argument evaluation happening before the call.

Making `content` by-name defers evaluation into the already-inline `debugDirectory.foreach` branch, so it's skipped entirely when debug output is disabled (the common case).

## Test plan
- [ ] `./mill jvm.test` / `./mill native.test` (CI)
- [ ] Compile-time benchmark vs `main` (in progress locally, will report the delta)

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)