### PR TITLE
Remove redundant Showable[Type[? <: T]] given instance

### DIFF
--- a/src/halotukozak/alpaca/internal/Showable.scala
+++ b/src/halotukozak/alpaca/internal/Showable.scala
@@ -6,7 +6,6 @@ import halotukozak.commons.*
 import halotukozak.made.*
 
 import scala.NamedTuple.NamedTuple
-import scala.annotation.targetName
 
 /**
  * A type class for converting values to their string representation.
@@ -82,11 +81,6 @@ private[internal] object Showable:
     show"[${quotes.reflect.Printer.TypeReprShortCode.show(tpe)}](${quotes.reflect.Printer.TypeReprStructure.show(tpe)})"
 
   given [T] => (quotes: Quotes) => Showable[Type[T]] =
-    import quotes.reflect.*
-    summon[Showable[TypeRepr]].transform(TypeRepr.of(using _))
-
-  @targetName("given_Type_bounds")
-  given [T] => (quotes: Quotes) => Showable[Type[? <: T]] =
     import quotes.reflect.*
     summon[Showable[TypeRepr]].transform(TypeRepr.of(using _))
 


### PR DESCRIPTION
## Summary

Addresses #512 (`Showable` implicit-search overhead in the library module, `jvm.compile`).

The issue flagged three candidates. After investigating each, only the first turned out to be a safe, verifiable win — I made that change and left the other two alone, with the reasoning below.

## Change made

`Showable.scala` had two overlapping `given` instances for `Quotes`-dependent `Type[_]`:

```scala
given [T] => (quotes: Quotes) => Showable[Type[T]] = ...

@targetName("given_Type_bounds")
given [T] => (quotes: Quotes) => Showable[Type[? <: T]] = ...
```

The `@targetName` annotation exists only because the two signatures erase identically — not because both are needed for implicit resolution. I verified this empirically: removing the second instance and recompiling produced *no* "no given instance found" errors anywhere in the module, only an unused-import warning for `scala.annotation.targetName` (now removed). Implicit search for `Showable[Type[? <: T]]` already resolves against the generic `Showable[Type[T]]` instance via wildcard skolemization.

Net effect: one fewer `Quotes`-dependent `given` in scope for the compiler to consider on every `Showable` search in the module (there were 8; now 7), with byte-for-byte identical resolution behavior at every existing call site.

## Candidates investigated and *not* changed

**`given [T: Showable] => Conversion[T, Shown]` (Showable.scala:47).** This looked like the more promising target (implicit conversions are searched more broadly than typeclass evidence), but it's not narrowly used — it's the mechanism that lets the `show"...$x..."` string interpolator accept any `Showable` argument directly, not just values already of type `Shown`. I confirmed this by temporarily disabling the given: every `show"...$x..."` call site in the module (~145 per the issue's profiling) failed to typecheck, plus two direct-conversion call sites in `createTables.scala` (passing a `Csv`/`ConflictResolutionTable` value where `Shown` was expected). Removing or narrowing this would require rewriting the interpolator itself, which is out of scope for a low-risk cleanup and would touch far more surface area than the win justifies.

**`Csv.toShowableList`'s `summonAll[Tuple.Map[T, Showable]]` (Csv.scala:56-62).** Traced actual usage: only 2 call sites (both `.toCsv` invocations in `createTables.scala`), and since `toShowableList` is `inline`, each `summonAll` only fires once per textual call site at compile time — not once per runtime row, as the issue's framing suggested. Already minimal; there's no safe way to "cache" a `compiletime.summonAll` result (it's a compile-time-only construct) without restructuring the derivation into a different macro shape, which risks behavior changes for no verified benefit.

## Verification

- `./mill jvm.compile` succeeds (clean and incremental).
- Read `ShowableTest.scala` to confirm the removed instance isn't exercised by any test expectation — it isn't; tests cover `String`/`Int`/case-class/`NamedTuple` derivation, none of which touch the `Quotes`-dependent `$COVERAGE-OFF$` block.
- Did not run `jvm.test`/`jvm.test.compile` locally per instructions (too slow); CI will run the test suite.

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)