### PR TITLE
Fail Compilation Benchmark job on >15% regression

### DIFF
--- a/.github/workflows/test-compilation-benchmark.yml
+++ b/.github/workflows/test-compilation-benchmark.yml
@@ -106,3 +106,17 @@ jobs:
           name: compilation-benchmark-result
           path: benchmark-result.json
           retention-days: 1
+
+      - name: Fail on Significant Regression
+        env:
+          BASE_MEAN: ${{ steps.extract.outputs.base_mean }}
+          CURR_MEAN: ${{ steps.extract.outputs.curr_mean }}
+        run: |
+          awk -v base="$BASE_MEAN" -v curr="$CURR_MEAN" 'BEGIN {
+            pct = (curr - base) / base * 100
+            printf "Base: %.3fs, Current: %.3fs, Delta: %.2f%%\n", base, curr, pct
+            if (pct > 15) {
+              printf "::error::Compilation time regressed by %.2f%% (> 15%% threshold)\n", pct
+              exit 1
+            }
+          }'


### PR DESCRIPTION
## Summary
- Adds a threshold check to the Compilation Benchmark workflow: if the current branch's mean compile time is more than 15% slower than base, the job fails.
- Placed after the benchmark result is saved/uploaded, so `comment-compilation-benchmark.yml` still posts the numbers even when the job fails.
- Only regressions trip it -- improvements (however large) never fail the job.

## Test plan
- [x] Verified the awk threshold logic locally against real numbers from #517 (3.83% regression -> pass) and #520 (18.71% improvement -> pass) and a synthetic 20% regression -> fail (exit 1).
- [ ] CI run on this PR itself (compares against main, should pass since no source changes).