### PR TITLE
Add a Scala.js target alongside jvm/native

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -10,6 +10,7 @@ package build
 import mill.*
 import mill.scalalib.*
 import mill.scalalib.publish.*
+import mill.scalajslib.*
 import mill.scalanativelib.*
 import mill.contrib.scoverage.ScoverageModule
 import mill.contrib.jmh.JmhModule
@@ -116,6 +117,12 @@ object `package` extends Module:
       // that depends on it lives in `test/src-jvm` (picked up automatically,
       // unlike `test/src` which both platforms compile) instead of `test/src`.
       override def mvnDeps = super.mvnDeps() ++ Seq(mvn"org.scalameta::scalameta:4.17.3")
+
+  object js extends Shared with ScalaJSModule:
+    def scalaJSVersion = "1.22.0"
+
+    object test extends ScalaTests with TestModule.ScalaTest with ScalaJSTests:
+      def scalaTestVersion = "3.2.20"
 
   object native extends Shared with ScalaNativeModule:
     def scalaNativeVersion = "0.5.12"

--- a/test/src/halotukozak/alpaca/TestHelpers.scala
+++ b/test/src/halotukozak/alpaca/TestHelpers.scala
@@ -2,12 +2,10 @@ package halotukozak
 package alpaca
 
 import halotukozak.alpaca.internal.lexer.LazyReader
-import java.nio.file.Files
+import java.io.StringReader
 import scala.util.Using
 
+// Backed by a StringReader rather than a real file so this helper (and the tests built on
+// it) stay portable to Scala.js, which has no java.nio.file filesystem support.
 inline def withLazyReader[A](fileContent: String)(inline action: LazyReader => A): A =
-  val tempFile = Files.createTempFile("test", ".txt")
-  try
-    Files.write(tempFile, fileContent.getBytes)
-    Using.resource(LazyReader.from(tempFile))(action)
-  finally Files.deleteIfExists(tempFile)
+  Using.resource(LazyReader(StringReader(fileContent), fileContent.length))(action)


### PR DESCRIPTION
## Summary
- Adds `object js extends Shared with ScalaJSModule` in `build.mill` (scalaJSVersion 1.22.0, matching the version the scala-cli repos use elsewhere in the org). `regex` and `made` both already publish `_sjs1_3` artifacts at the pinned versions, so `Shared`'s `mvnDeps` resolve for `js` the same way they already do for `native`.
- Fixes `TestHelpers.withLazyReader`, which wrote content to a real temp file via `java.nio.file.Files` and read it back through `LazyReader.from(path)`. `java.nio.file` has no Scala.js shim, so any test using this helper (5 files, including `CompilationTheoryTest`) failed Scala.js linking with `Referring to non-existent class java.nio.file.Files`. Switched it to build the `LazyReader` directly from a `java.io.StringReader` — same behavior, one less platform dependency, simpler than the file it replaces.
- No CI workflow changes needed: `tests.yml`'s `discover` job asks Mill which top-level modules have a `.test` submodule, so it picks up `js` automatically once this merges.

## Test plan
- [x] `CI=true ./mill jvm.test` — 352 tests pass
- [x] `CI=true ./mill native.test` — 291 tests pass
- [x] `CI=true ./mill js.test` — 291 tests pass (was failing on linking before the `TestHelpers` fix)
- [x] `CI=true ./mill jvm.docJar` — unaffected
- [x] `./mill mill.scalalib.scalafmt/checkFormatAll` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01CaPNFyF7KLpvM8gDf5KbBt