### PR TITLE
Fix stale README: broken build commands, wrong Mill dep syntax, dead links

### DIFF
--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -10,6 +10,7 @@ A type-safe lexer and parser library for Scala 3, featuring compile-time validat
 - **Macro-based code generation** — Scala 3 macros generate efficient tokenizers and parse tables
 - **Context-aware** — lexical and parsing contexts with type-safe state management
 - **LR(1) parsing** — automatic parse table generation with conflict detection
+- **Cross-platform** — runs on the JVM, Scala.js, and Scala Native
 
 ## Installation
 
@@ -30,7 +31,7 @@ object myproject extends ScalaModule {
   def scalacOptions = Seq("-Yretain-trees", "-experimental")
 
   def mvnDeps = Seq(
-    mvn"com.halotukozak::alpaca:0.2.0"
+    mvn"com.halotukozak::alpaca::0.2.0"
   )
 }
 ```
@@ -159,25 +160,28 @@ Runtime benchmarks are **not** run automatically in CI on push or pull requests.
 
 ### Build Commands
 
+The build defines separate `jvm`, `js`, and `native` modules; commands below target `jvm` (swap in
+`js`/`native` to build for those platforms):
+
 ```bash
 # Compile the project
-./mill compile
+./mill jvm.compile
 
 # Run tests
-./mill test
+./mill jvm.test
 
 # Generate documentation
-./mill docJar
+./mill jvm.docJar
 
 # Run test coverage
-./mill test.scoverage.htmlReport
+./mill jvm.scoverage.htmlReport
 ```
 
 ## Thesis
 
 This project was developed as a Bachelor's Thesis. The full text is available in
-the [thesis.pdf](https://github.com/halotukozak/alpaca/blob/master/thesis.pdf) file. The LaTeX source files are on
-the `thesis` [branch](https://github.com/halotukozak/alpaca/tree/thesis). The thesis is written in Polish
+the [thesis.pdf](https://github.com/halotukozak-com/alpaca/blob/main/thesis.pdf) file. The LaTeX source files are on
+the `thesis` [branch](https://github.com/halotukozak-com/alpaca/tree/thesis). The thesis is written in Polish
 and does not represent the current state of the project.
 
 ## Contributing


### PR DESCRIPTION
## Summary
README.md is a symlink to `docs/_docs/index.md`; this edits that file.

- **Build Commands were broken as written.** `./mill compile`, `./mill test`, `./mill docJar`, `./mill test.scoverage.htmlReport` don't resolve anymore — the build defines separate `jvm`/`js`/`native` modules, so these need a module prefix. Fixed to `./mill jvm.compile` etc., with a note that `js`/`native` work the same way.
- **Mill install snippet had wrong dependency syntax.** `mvn"com.halotukozak::alpaca:0.2.0"` (single colon before the version) doesn't do cross-Scala-version resolution the way `::` does — this repo's own `build.mill` uses `mvn"com.halotukozak::regex::0.2.0"` for the same kind of dependency. Fixed to match.
- **Thesis section had dead links.** Pointed at `github.com/halotukozak/alpaca` (redirects to the org) on a `master` branch that doesn't exist (302). Updated to `github.com/halotukozak-com/alpaca` on `main` (200).
- **Added a "Cross-platform" bullet to Features** — the project builds for jvm/js/native but nothing in the README said so.

## Test plan
- [x] `./mill resolve jvm.compile jvm.test jvm.docJar jvm.scoverage.htmlReport` — all resolve
- [x] Checked both link targets return 200
- [x] Confirmed `mvn"org::artifact::version"` matches this repo's own build.mill usage

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01CaPNFyF7KLpvM8gDf5KbBt