### PR TITLE
Fix CI env detection and restore -Wsafe-init to common scalacOptions

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -21,6 +21,12 @@ object `package` extends Module:
   trait Shared extends ScalaModule with PlatformScalaModule with SonatypeCentralPublishModule:
     def scalaVersion = "3.9.0"
 
+    // Task.env (not sys.env) is required here: Mill's persistent daemon captures its own
+    // process environment once at startup, so a plain `sys.env` read inside a cached Task
+    // never sees a `CI` value set after the daemon first launched. Task.Input re-reads and
+    // re-tracks it on every invocation, correctly invalidating scalacOptions when it changes.
+    def isCI: T[Boolean] = Task.Input { Task.env.contains("CI") }
+
     // Diagnostic/checking flags cost real compile time and only earn their keep in CI, where
     // that cost is paid once instead of on every local build.
     override def scalacOptions = Task {
@@ -34,6 +40,13 @@ object `package` extends Module:
         "-Vprofile",
         "-Werror",
         "-Yexplicit-nulls",
+        // Not purely diagnostic: productionImpl (Parser.scala) walks a parser subclass's
+        // declarations via reflection to build the `production` selector, and without this
+        // flag that walk sees a different member order/shape, tripping "Define resolutions
+        // as the last field of the parser" on parsers that are otherwise valid. Confirmed by
+        // bisecting the dev/CI scalacOptions split (#518) after it broke `jvm.test.compile`
+        // locally -- keep this in `common` even though every other check here is CI-only.
+        "-Wsafe-init",
         // Scala 3.9 generates larger trees for lexerImpl/createTablesImpl than 3.8 did, pushing
         // them past the compiler's hardcoded 3000-node coverage-instrumentation threshold
         // (dotty.tools.dotc.transform.InstrumentCoverage.MaxInstrumentableTreeNodes - not
@@ -60,12 +73,11 @@ object `package` extends Module:
         // "-Xprint:postInlining",
         // "-Xprint-suspension",
         // "-Vprint:typer",
-        "-Wsafe-init",
         "-Yshow-suppressed-errors",
         "-Yshow-var-bounds",
         "-Wunused:all",
       )
-      if sys.env.contains("CI") then common ++ ciOnly else common
+      if isCI() then common ++ ciOnly else common
     }
 
     override def scalaDocOptions = Task {


### PR DESCRIPTION
## Summary
Two bugs introduced by #518's dev/CI scalacOptions split, both discovered while debugging why `main`'s `jvm.test.compile` failed locally with 132 "Define resolutions as the last field of the parser" errors, despite CI staying green:

1. **`sys.env.contains("CI")` never sees `CI` set locally.** Mill's persistent per-worktree daemon captures its own process environment once at startup; a plain `sys.env` read inside a cached `Task` reads that frozen snapshot, not each invocation's actual environment. Setting `CI=true` in the shell -- even after `./mill shutdown` and a fresh daemon start -- had no effect. Replaced with `Task.env` inside a `Task.Input`, Mill's documented pattern for env-dependent tasks that need correct per-invocation tracking and invalidation.
2. **`-Wsafe-init` isn't purely diagnostic.** It was moved into the CI-only flag set, but `productionImpl` (`Parser.scala`) walks a parser subclass's declarations via reflection to build the `production` selector, and without `-Wsafe-init` that walk sees a different member shape -- spuriously tripping "Define resolutions as the last field of the parser" on parsers that are otherwise valid. Moved back to `common`.

Bug #2 alone would have broken every local dev build once bug #1's fix made `isCI()` correctly evaluate to `false` locally (as intended by #518). Bug #1 alone is why this went unnoticed on CI: GitHub Actions sets `CI=true` before the Mill daemon is ever spawned in a job, so the daemon's captured environment always includes it there, masking the detection bug entirely.

## Test plan
- [x] `./mill jvm.compile` -- success
- [x] `./mill jvm.test` without `CI` set -- 188/188, all tests pass
- [x] `./mill jvm.test` with `CI=true` -- 188/188, all tests pass
- [x] Confirmed via `./mill show jvm.scalacOptions`, same running daemon, that setting `CI=true` now correctly flips the flag set without a daemon restart
- [x] Bisected the 9 CI-only flags individually to confirm `-Wsafe-init` alone (not `-Ycheck:macros`, `-Wunused:all`, or the others) is what's load-bearing