### PR TITLE
Replace canonical LR(1) parse-table construction with LALR(1)

### DIFF
--- a/src/halotukozak/alpaca/internal/parser/Core.scala
+++ b/src/halotukozak/alpaca/internal/parser/Core.scala
@@ -1,0 +1,51 @@
+package halotukozak
+package alpaca
+package internal
+package parser
+
+import halotukozak.alpaca.internal.{AlgorithmError, Showable}
+
+/**
+ * An LR(0) item: a production with a dot position, deliberately without a lookahead.
+ *
+ * This is the unit of identity for the LR(0) automaton built during LALR(1) construction
+ * (#504): two [[Item]]s that differ only by lookahead share the same `Core`, which is what
+ * keeps that automaton's state count down to the LALR(1) count instead of the (often
+ * 10-50x larger) canonical LR(1) count. Lookaheads are determined afterward by propagating
+ * them over this automaton (see [[Lookaheads]]) rather than being threaded through closure.
+ *
+ * @param production  the grammar production
+ * @param dotPosition the position of the dot (0 to production.rhs.size)
+ */
+private[parser] final case class Core(production: Production, dotPosition: Int):
+
+  /**
+   * The symbol immediately after the dot.
+   *
+   * Callers must guard with `!isLastItem`; on the last item this throws (the exact exception
+   * depends on the production kind, not part of this method's contract).
+   */
+  def nextSymbol: Symbol = production match
+    case Production.NonEmpty(_, rhs, _) => rhs(dotPosition)
+    case _: Production.Empty => throw AlgorithmError(s"$this is the last item, has no next symbol")
+
+  /** The core with the dot advanced by one position. Callers must guard with `!isLastItem`. */
+  def nextCore: Core = Core(production, dotPosition + 1)
+
+  /** Whether the dot is at the end of the production. */
+  val isLastItem: Boolean = production match
+    case Production.NonEmpty(_, rhs, _) => rhs.sizeIs == dotPosition
+    case _: Production.Empty => true
+
+private[parser] object Core:
+  /** The core of a production with the dot at position 0. */
+  def apply(production: Production): Core = Core(production, 0)
+
+  given Ordering[Core] = Ordering.by[Core, Int](_.production.hashCode).orElseBy(_.dotPosition)
+
+  given Showable[Core] =
+    case Core(Production.NonEmpty(lhs, rhs, name), dotPosition) =>
+      val (left, right) = rhs.splitAt(dotPosition)
+      show"$lhs -> ${left.mkShow}•${right.mkShow}"
+    case Core(Production.Empty(lhs, name), _) =>
+      show"$lhs -> •${Symbol.Empty}"

--- a/src/halotukozak/alpaca/internal/parser/LR0Automaton.scala
+++ b/src/halotukozak/alpaca/internal/parser/LR0Automaton.scala
@@ -1,0 +1,65 @@
+package halotukozak
+package alpaca
+package internal
+package parser
+
+import scala.collection.mutable
+
+/**
+ * The LR(0) automaton built as the first phase of LALR(1) construction (#504).
+ *
+ * @param states  the automaton's states, dense-indexed
+ * @param kernels each state's kernel items -- the initial item for state 0, or (for any other
+ *                state) the cores obtained by advancing the dot on whichever items of its
+ *                predecessor state shifted into it. Every other item in a state's closure is
+ *                derivable from its kernel, so lookahead propagation (see [[Lookaheads]]) only
+ *                needs to track kernels.
+ * @param goto    each state's outgoing shift transitions by symbol
+ */
+private[parser] final case class LR0Automaton(
+  states: IndexedSeq[LR0State],
+  kernels: IndexedSeq[List[Core]],
+  goto: IndexedSeq[Map[Symbol, Int]],
+)
+
+private[parser] object LR0Automaton:
+  /**
+   * Constructs the LR(0) automaton for a grammar.
+   *
+   * Closure here never consults `FirstSet` -- combined with states being keyed by [[Core]]
+   * (dropping lookahead from item identity), this is what keeps automaton construction cheap
+   * relative to canonical LR(1), independent of the lookahead-propagation phase that follows.
+   *
+   * @param productionsByLhs all grammar productions, indexed by their LHS non-terminal
+   * @return the constructed automaton
+   */
+  def apply(productionsByLhs: Map[NonTerminal, List[Production]]): LR0Automaton =
+    val initialKernel = Core(productionsByLhs(parser.Symbol.Start).head)
+    val initialState = LR0State.fromCore(LR0State.empty, initialKernel, productionsByLhs)
+
+    val states = mutable.ArrayBuffer(initialState)
+    val kernels = mutable.ArrayBuffer(List(initialKernel))
+    val gotoRows = mutable.ArrayBuffer(mutable.HashMap.empty[Symbol, Int])
+    val stateIndex = mutable.HashMap(initialState -> 0)
+
+    var currStateId = 0
+    while states.sizeIs > currStateId do
+      val currState = states(currStateId)
+
+      for (stepSymbol, cores) <- currState.itemsByNextSymbol do
+        val newState = LR0State.nextState(cores, productionsByLhs)
+
+        val stateId = stateIndex.getOrElseUpdate(
+          newState, {
+            val newId = states.length
+            states += newState
+            kernels += cores.map(_.nextCore)
+            gotoRows += mutable.HashMap.empty
+            newId
+          },
+        )
+        gotoRows(currStateId).update(stepSymbol, stateId)
+
+      currStateId += 1
+
+    LR0Automaton(states.toIndexedSeq, kernels.toIndexedSeq, gotoRows.map(_.toMap).toIndexedSeq)

--- a/src/halotukozak/alpaca/internal/parser/LR0State.scala
+++ b/src/halotukozak/alpaca/internal/parser/LR0State.scala
@@ -1,0 +1,68 @@
+package halotukozak
+package alpaca
+package internal
+package parser
+
+import scala.annotation.tailrec
+import scala.collection.immutable.SortedSet
+
+/**
+ * An opaque type representing a state of the LR(0) automaton built during LALR(1)
+ * construction (#504).
+ *
+ * Unlike [[State]] (a set of lookahead-carrying [[Item]]s), closure here never consults
+ * `FirstSet` -- it only follows productions by LHS -- which is the other half (besides the
+ * smaller state count from [[Core]] merging) of why this automaton is cheap to build.
+ */
+opaque private[parser] type LR0State <: SortedSet[Core] = SortedSet[Core]
+
+private[parser] object LR0State:
+
+  val empty: LR0State = SortedSet.empty[Core]
+
+  extension (state: LR0State)
+
+    /**
+     * Groups this state's non-final items by the symbol they can shift on next.
+     *
+     * @return a map from each possible step symbol to the cores that shift on it
+     */
+    def itemsByNextSymbol: Map[Symbol, List[Core]] =
+      state.iterator.filterNot(_.isLastItem).toList.groupBy(_.nextSymbol) - Symbol.Empty
+
+  /**
+   * Computes the state reached after shifting a symbol.
+   *
+   * @param cores            the cores that shift on the symbol being stepped to (see [[itemsByNextSymbol]])
+   * @param productionsByLhs all grammar productions, indexed by their LHS non-terminal
+   * @return the new state
+   */
+  def nextState(cores: List[Core], productionsByLhs: Map[NonTerminal, List[Production]]): LR0State =
+    cores.foldLeft(LR0State.empty)((acc, core) => LR0State.fromCore(acc, core.nextCore, productionsByLhs))
+
+  /**
+   * Constructs a state closure from a single LR(0) item.
+   *
+   * @param state            the current state to add to
+   * @param core             the item to close
+   * @param productionsByLhs all grammar productions, indexed by their LHS non-terminal
+   * @return the closed state
+   */
+  def fromCore(state: LR0State, core: Core, productionsByLhs: Map[NonTerminal, List[Production]]): LR0State =
+    @tailrec def loop(state: LR0State, pending: Set[Core], worklist: List[Core]): LR0State = worklist match
+      case Nil => state
+      case core :: rest if core.isLastItem => loop(state + core, pending, rest)
+      case core :: rest =>
+        core.nextSymbol match
+          case nt: NonTerminal =>
+            val newState = state + core
+            val newCores = productionsByLhs
+              .getOrElse(nt, Nil)
+              .iterator
+              .map(Core(_))
+              .filterNot(candidate => newState.contains(candidate) || pending.contains(candidate))
+              .toList
+            loop(newState, pending ++ newCores, newCores ::: rest)
+          case _: Terminal => loop(state + core, pending, rest)
+
+    loop(state, Set.empty, core :: Nil)

--- a/src/halotukozak/alpaca/internal/parser/Lookaheads.scala
+++ b/src/halotukozak/alpaca/internal/parser/Lookaheads.scala
@@ -1,0 +1,67 @@
+package halotukozak
+package alpaca
+package internal
+package parser
+
+import halotukozak.alpaca.internal.DebugSettings
+
+import scala.collection.mutable
+
+/**
+ * Computes LALR(1) lookaheads for every kernel item of every state of an [[LR0Automaton]]
+ * (#504), via the spontaneous-generation-and-propagation algorithm (DeRemer & Pennello 1982).
+ *
+ * For each kernel item, this closes it once on its own, seeded with the placeholder lookahead
+ * [[Symbol.Dummy]] (reusing [[State.fromItem]], the same closure [[ParseTable]] uses once real
+ * lookaheads are known). Within that one-off closure, whatever a resulting item's lookahead is
+ * tells us how the *target* item (the one reached by shifting past it) gets its lookahead:
+ *   - a real terminal means that terminal is generated spontaneously for the target item,
+ *     regardless of what the seed kernel item's own lookahead eventually turns out to be.
+ *   - the placeholder surviving through means the target item's lookahead set is whatever the
+ *     seed kernel item's turns out to be -- a propagation edge, resolved below.
+ *
+ * Propagation edges are then followed to a fixed point over the automaton (small relative to
+ * canonical LR(1) by construction), rather than over an exploded per-lookahead state space.
+ */
+private[parser] object Lookaheads:
+  def apply(
+    automaton: LR0Automaton,
+    productionsByLhs: Map[NonTerminal, List[Production]],
+    firstSet: FirstSet,
+  )(using DebugSettings,
+  ): IndexedSeq[Map[Core, Set[Terminal]]] =
+    val lookaheads =
+      automaton.kernels.map(kernel => mutable.Map.from(kernel.iterator.map(_ -> mutable.Set.empty[Terminal])))
+    val propagatesTo =
+      automaton.kernels.map(kernel => mutable.Map.from(kernel.iterator.map(_ -> List.empty[(Int, Core)])))
+
+    val worklist = mutable.ArrayDeque.empty[(Int, Core)]
+
+    // The augmented start item is the one place a lookahead is known outright, not derived.
+    // It must be seeded onto the worklist too, or nothing ever propagates from it.
+    lookaheads(0)(automaton.kernels(0).head) += Symbol.EOF
+    worklist.append((0, automaton.kernels(0).head))
+
+    for
+      stateId <- automaton.states.indices
+      kernelCore <- automaton.kernels(stateId)
+    do
+      val seed = Item(kernelCore.production, kernelCore.dotPosition, Symbol.Dummy)
+      val dummyClosure = State.fromItem(State.empty, seed, productionsByLhs, firstSet)
+
+      for item <- dummyClosure if !item.isLastItem do
+        val targetState = automaton.goto(stateId)(item.nextSymbol)
+        val targetCore = Core(item.production, item.dotPosition + 1)
+
+        if item.lookAhead == Symbol.Dummy then propagatesTo(stateId)(kernelCore) ::= (targetState, targetCore)
+        else if lookaheads(targetState)(targetCore).add(item.lookAhead) then worklist.append((targetState, targetCore))
+
+    while worklist.nonEmpty do
+      val (stateId, kernelCore) = worklist.removeHead()
+      for (targetState, targetCore) <- propagatesTo(stateId)(kernelCore) do
+        val toAdd = lookaheads(stateId)(kernelCore).diff(lookaheads(targetState)(targetCore))
+        if toAdd.nonEmpty then
+          lookaheads(targetState)(targetCore) ++= toAdd
+          worklist.append((targetState, targetCore))
+
+    lookaheads.map(_.view.mapValues(_.toSet).toMap)

--- a/src/halotukozak/alpaca/internal/parser/ParseTable.scala
+++ b/src/halotukozak/alpaca/internal/parser/ParseTable.scala
@@ -62,44 +62,36 @@ private[parser] object ParseTable:
       Csv(headers, rows)
 
   /**
-   * Constructs the LR(1) parse table from a list of productions.
+   * Constructs the LALR(1) parse table from a list of productions (#504).
    *
-   * This implements the LR(1) parser construction algorithm. It builds
-   * states by computing closures of item sets and constructs the parse
-   * table that maps (state, symbol) pairs to actions (shift or reduce).
+   * This builds the (much smaller than canonical-LR(1)) LR(0) automaton first
+   * ([[LR0Automaton]]), determines each state's lookaheads by propagation over it
+   * ([[Lookaheads]]), then closes each state once more with its real lookaheads (reusing
+   * [[State.fromItem]]) to read off reduce actions; shift actions come straight from the
+   * automaton's already-computed goto transitions.
    *
    * @param productions the grammar productions
    * @return the constructed parse table
    * @throws ConflictException if the grammar has shift/reduce or reduce/reduce conflicts
    */
-  // Deliberately sequential (see #31): states are discovered incrementally as a side
-  // effect of processing earlier ones, so parallelizing safely would need a frontier-based
-  // BFS rewrite with concurrent state dedup -- not worth the correctness risk without a
-  // measured compile-time bottleneck on a real grammar.
   def apply(productions: List[Production], conflictResolutionTable: ConflictResolutionTable)(using DebugSettings)
     : ParseTable =
     val firstSet = FirstSet(productions)
     val productionsByLhs = productions.groupBy(_.lhs)
-    var currStateId = 0
-    val initialState = State.fromItem(
-      state = State.empty,
-      item = productionsByLhs(parser.Symbol.Start).head.toItem(),
-      productionsByLhs = productionsByLhs,
-      firstSet = firstSet,
-    )
-    val states = mutable.ArrayBuffer(initialState)
-    val stateIndex = mutable.HashMap(initialState -> 0)
-    val tableRows = mutable.ArrayBuffer(mutable.HashMap.empty[Symbol, ParseAction])
+    val automaton = LR0Automaton(productionsByLhs)
+    val lookaheads = Lookaheads(automaton, productionsByLhs, firstSet)
 
-    def addToTable(symbol: Symbol, action: ParseAction): Unit =
-      val row = tableRows(currStateId)
+    val tableRows = mutable.ArrayBuffer.fill(automaton.states.length)(mutable.HashMap.empty[Symbol, ParseAction])
+
+    def addToTable(stateId: Int, symbol: Symbol, action: ParseAction): Unit =
+      val row = tableRows(stateId)
       row.get(symbol) match
         case None => row.update(symbol, action)
         case Some(existingAction) =>
           conflictResolutionTable.get(existingAction, action)(symbol) match
             case Some(action) => row.update(symbol, action)
             case None =>
-              val path = toPath(currStateId, List(symbol))
+              val path = toPath(stateId, List(symbol))
               (existingAction, action) match
                 case (red1: Reduction, red2: Reduction) => throw ReduceReduceConflict(red1, red2, path)
                 case (Shift(_), red: Reduction) => throw ShiftReduceConflict(symbol, red, path)
@@ -120,25 +112,18 @@ private[parser] object ParseTable:
         if sourceStateId == stateId then symbol :: acc
         else toPath(sourceStateId, symbol :: acc)
 
-    while states.sizeIs > currStateId do
-      val currState = states(currStateId)
+    for stateId <- automaton.states.indices do
+      val kernelItems = for
+        kernelCore <- automaton.kernels(stateId)
+        la <- lookaheads(stateId)(kernelCore)
+      yield Item(kernelCore.production, kernelCore.dotPosition, la)
 
-      for item <- currState if item.isLastItem do addToTable(item.lookAhead, Reduction(item.production))
+      val currState =
+        kernelItems.foldLeft(State.empty)((acc, item) => State.fromItem(acc, item, productionsByLhs, firstSet))
 
-      for (stepSymbol, items) <- currState.itemsByNextSymbol do
-        val newState = State.nextState(items, productionsByLhs, firstSet)
+      for item <- currState if item.isLastItem do addToTable(stateId, item.lookAhead, Reduction(item.production))
 
-        val stateId = stateIndex.getOrElseUpdate(
-          newState, {
-            val newId = states.length
-            states += newState
-            tableRows += mutable.HashMap.empty
-            newId
-          },
-        )
-        addToTable(stepSymbol, Shift(stateId))
-
-      currStateId += 1
+      for (stepSymbol, targetStateId) <- automaton.goto(stateId) do addToTable(stateId, stepSymbol, Shift(targetStateId))
 
     Array.better.tabulate(tableRows.length)(tableRows(_).toMap)
 

--- a/src/halotukozak/alpaca/internal/parser/State.scala
+++ b/src/halotukozak/alpaca/internal/parser/State.scala
@@ -27,39 +27,6 @@ private[parser] object State:
       .orElseBy(_.lookAhead.name),
   )
 
-  extension (state: State)
-
-    /**
-     * Groups this state's non-final items by the symbol they can shift on next.
-     *
-     * Computed once per state and reused for every step symbol, instead of each step
-     * re-scanning the whole state to find its items (`nextSymbol` was otherwise called once
-     * per item per step symbol -- proportional to state fan-out, not state size).
-     *
-     * @return a map from each possible step symbol to the items that shift on it
-     */
-    def itemsByNextSymbol: Map[Symbol, List[Item]] =
-      state.iterator.filterNot(_.isLastItem).toList.groupBy(_.nextSymbol) - Symbol.Empty
-
-  /**
-   * Computes the state reached after shifting a symbol.
-   *
-   * This advances the dot in all given items, then closes the set by adding all items
-   * derivable from non-terminals.
-   *
-   * @param items            the items that shift on the symbol being stepped to (see [[itemsByNextSymbol]])
-   * @param productionsByLhs all grammar productions, indexed by their LHS non-terminal
-   * @param firstSet         the FIRST sets for lookahead computation
-   * @return the new state
-   */
-  def nextState(
-    items: List[Item],
-    productionsByLhs: Map[NonTerminal, List[Production]],
-    firstSet: FirstSet,
-  )(using DebugSettings,
-  ): State =
-    items.foldLeft(State.empty)((acc, item) => State.fromItem(acc, item.nextItem, productionsByLhs, firstSet))
-
   /**
    * Constructs a state closure from a single item.
    *

--- a/src/halotukozak/alpaca/internal/parser/Symbol.scala
+++ b/src/halotukozak/alpaca/internal/parser/Symbol.scala
@@ -89,6 +89,16 @@ private[parser] object Symbol:
   /** The empty terminal symbol (epsilon). */
   val Empty: Terminal { type IsEmpty = true } = Terminal("ε").asInstanceOf[Terminal { type IsEmpty = true }]
 
+  /**
+   * Placeholder lookahead used only while propagating LALR(1) lookaheads (#504, see
+   * [[Lookaheads]]). Never appears in a real reduce action or parse table entry -- within a
+   * per-kernel-item closure seeded with this symbol, any item that still carries it means "this
+   * item's real lookahead is whatever the seed's turns out to be" (propagation), while any other
+   * terminal it closure-generates is a lookahead the target state gets regardless of the seed
+   * (spontaneous generation).
+   */
+  val Dummy: Terminal { type IsEmpty = false } = Terminal("#")
+
   given Showable[Symbol] = symbol =>
     if symbol.name.contains(SyntheticInfix) then show"<synthetic from ${symbol.name.takeWhile(_ != '$')}>"
     else


### PR DESCRIPTION
Closes #504.

## Summary
- Builds the LR(0) automaton first (`Core`/`LR0State`/`LR0Automaton`): states keyed by `(production, dotPosition)` only, closure that never consults FIRST sets.
- Determines each state's lookaheads afterward by propagation over that (much smaller) automaton (`Lookaheads`, DeRemer & Pennello 1982's spontaneous-generation-and-propagation algorithm), instead of threading lookaheads through closure like canonical LR(1) does.
- `ParseTable.apply` closes each state once more with its real (now-known) lookaheads, reusing the existing `State.fromItem`, to read off reduce actions; shifts come straight from the automaton's precomputed goto transitions.
- Removed `State.nextState`/`State.itemsByNextSymbol` (dead -- superseded by `LR0State`'s equivalents, used one construction phase earlier).

This is expected to be the milestone's single highest-impact fix (~90% of the audited slowdown), since canonical LR(1) is known to produce 10-50x more states than LALR(1) for grammars with many ambiguous infix operators (e.g. `ScalaParser`'s `Expr -> Expr op Expr` family), and the exploded state count is what dominates macro-expansion time, not just final table size.

## Correctness
LALR(1) can in principle introduce reduce-reduce conflicts that canonical LR(1) wouldn't have (an inherent LALR(1) vs LR(1) trade-off, not a bug) -- none of this repo's grammars hit that in practice; the full test suite (including `ScalaParser`, `CompilationTheoryTest`, `MathTest`, and the `ParseTableTest`/`ParseTableRuntimeTest` conflict-detection tests) passes unmodified on both `jvm` and `native`.

## Test plan
- [x] `./mill jvm.test` -- 188/188, all suites pass (including `ParseTableTest`'s Shift-Reduce, Reduce-Reduce, and conflict-cycle-detection tests, which still correctly fire since those conflicts are structural to the grammars, not LALR-merge artifacts)
- [x] `./mill native.test` -- 291/291, all pass
- [x] `./mill mill.scalalib.scalafmt/checkFormatAll` -- clean
- [x] Verified via a throwaway debug harness that lookahead propagation is correct on a small hand-built grammar (including a real reduce-reduce conflict that a buggy first pass at the propagation algorithm was silently swallowing -- caught by `ParseTableTest`, fixed, re-verified) before removing the harness

## Benchmark
Will report the CI Compilation Benchmark numbers once they land -- this is the change the whole milestone was built around, so worth confirming the actual measured win rather than just trusting the theory.