### PR TITLE
Stream live progress from the Compilation Benchmark job

### DIFF
--- a/.github/workflows/test-compilation-benchmark.yml
+++ b/.github/workflows/test-compilation-benchmark.yml
@@ -64,7 +64,12 @@ jobs:
             (
               cd "$dir"
 
-              hyperfine --runs 5 \
+              # --show-output: without it, hyperfine buffers the benchmarked command's own
+              # output and only prints its summary once ALL 5 runs finish -- on a job that
+              # routinely takes 10+ minutes per run, that's a long silent wait with nothing in
+              # the log to show it's alive. With it, Mill's own per-run compile progress streams
+              # through as each run happens.
+              hyperfine --runs 5 --show-output \
                 --prepare "./mill clean && ./mill jvm.compile" \
                 "./mill jvm.test.compile" \
                 --export-json "../${dir}.json"

--- a/.github/workflows/test-compilation-benchmark.yml
+++ b/.github/workflows/test-compilation-benchmark.yml
@@ -64,11 +64,6 @@ jobs:
             (
               cd "$dir"
 
-              # --show-output: without it, hyperfine buffers the benchmarked command's own
-              # output and only prints its summary once ALL 5 runs finish -- on a job that
-              # routinely takes 10+ minutes per run, that's a long silent wait with nothing in
-              # the log to show it's alive. With it, Mill's own per-run compile progress streams
-              # through as each run happens.
               hyperfine --runs 5 --show-output \
                 --prepare "./mill clean && ./mill jvm.compile" \
                 "./mill jvm.test.compile" \


### PR DESCRIPTION
## Summary
- Adds `--show-output` to the hyperfine invocation in `test-compilation-benchmark.yml`.
- Confirmed locally: without it, hyperfine buffers the benchmarked command's own stdout and prints nothing until every run of a benchmark finishes -- on a job where a single `jvm.test.compile` run routinely takes 10+ minutes, that means the CI log sits completely silent for the whole benchmark, with no way to tell it's still alive vs. hung.
- With `--show-output`, Mill's own per-run compile progress (which it already prints incrementally as it works) streams into the log as each of the 5 runs happens, for both the `--prepare` step and the benchmarked command.

## Test plan
- [x] Verified locally with a toy hyperfine invocation (`--runs 2 --show-output --prepare "echo prep" "echo run; sleep 1" --export-json ...`) that output streams live (visible mid-run, not just at the end) and that `--export-json` output is unaffected.