### PR TITLE
Patch scaladoc's jQuery-dependent same-page navigation in docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,18 @@ jobs:
 
       - name: Generate docs
         run: ./mill jvm.docJar
+
+      # Scaladoc's bundled ux.js still calls jQuery's `$.get` for its SPA-style same-page
+      # navigation (sidebar/TOC link clicks), but scaladoc no longer ships jQuery itself.
+      # That throws "ReferenceError: Can't find variable: $" on every in-page link click,
+      # and since the handler already called preventDefault(), navigation just silently
+      # breaks. Fixed upstream (scala/scala3#22014) but not yet in the scaladoc version
+      # this project builds with -- swap the jQuery call for a native fetch() until then.
+      - name: Patch scaladoc jQuery navigation bug
+        run: |
+          sed -i 's/\$\.get(href, function (data) {/fetch(href).then((r) => r.text()).then(function (data) {/' \
+            out/jvm/docJar.dest/docs/scripts/ux.js
+
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- This project builds docs with Scala **3.9.0**. Its bundled `ux.js` still calls jQuery's `$.get` for SPA-style same-page navigation (sidebar/TOC link clicks), but scaladoc no longer ships jQuery.
- Every in-page link click threw `ReferenceError: Can't find variable: $` right after the handler had already called `preventDefault()`, so navigation (e.g. clicking sidebar tabs) silently broke on the deployed docs site.
- Patches the generated `ux.js` in the `docs.yml` workflow, right after `./mill jvm.docJar`, swapping the jQuery call for an equivalent native `fetch()` call.

## Root cause (upstream)
`ux.js` at 3.9.0 is the result of a partially-landed jQuery removal on the 3.9 release line (scala/scala3 commit `e9fa46b8ca`, part of [scala/scala3#22014](https://github.com/scala/scala3/pull/22014)): it dropped the `code.jquery.com/jquery-3.5.1.min.js` `<script>` from `Resources.scala` but left the jQuery calls in `ux.js` — `$.get` at `ux.js:180` (the link-click handler this PR patches) plus `$(...)` at ~line 95 and ~line 130 (documentable-element expanders and the inheritance graph). Only the `$.get` one breaks navigation; the others break less common interactions the same way.

On `main` this is fully fixed by two PRs:
- [scala/scala3#26664](https://github.com/scala/scala3/pull/26664) "Scaladoc: Stop hijacking link clicks" — deletes the whole link-hijack block (incl. `$.get`).
- [scala/scala3#22014](https://github.com/scala/scala3/pull/22014) (commit `4658d688e9`) — removes the remaining `$(...)` calls in `ux.js`.

Both are in the released **`3.10.0-RC1`** tag (2026-08-27); neither is in `3.9.0` or any `3.9.0-RC*`. The `lts-3.9` branch (heading to 3.9.1 LTS) is still broken.

## Follow-up
- Once scaladoc **3.10.0** is out (or when bumping to a `3.10.0-RC`), drop this `sed` patch — the fix is already in that line.
- Alternatively, get scala/scala3#26664 (and the `ux.js` hunk of #22014) backported onto `lts-3.9` so 3.9.1 LTS ships a working `ux.js`.

## Test plan
- [x] Ran `./mill jvm.docJar` locally, applied the same `sed` patch, verified `node --check` passes on the patched `ux.js`.
- [x] Confirmed no other script or generated HTML page loads jQuery, so `$.get` was the only reference breaking navigation.
- [ ] Once merged and deployed, click through sidebar/tab navigation on the live docs site to confirm same-page navigation works without console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
