### PR TITLE
docs.yml: deploy docs on push to main, not only on tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "**"
+    branches: [ "main" ]
 
   workflow_dispatch:
 


### PR DESCRIPTION
Every other halotukozak-com library (commons, made, mcodec, mrpc, regex) redeploys its scaladoc site on each push to the default branch. alpaca's `docs.yml` only fired on tag pushes (`tags: "**"`), so the published Pages site drifted behind `main` between releases.

This adds `branches: [ "main" ]` to the `push` trigger, keeping the existing tag and `workflow_dispatch` triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)