### PR TITLE
Add IntelliJ plugin publishing tooling

### DIFF
--- a/.github/workflows/ij-plugin-publish.yml
+++ b/.github/workflows/ij-plugin-publish.yml
@@ -1,0 +1,71 @@
+name: Publish IntelliJ Plugin
+
+# Manual-only: the repo's `v*` tags already drive the Scala library's Sonatype publish
+# and any tag drives the docs deploy, so the plugin gets its own explicitly-triggered
+# workflow instead of a tag pattern. Release flow:
+#   1. bump `version` in ij-plugin/gradle.properties
+#   2. run `./gradlew patchChangelog` in ij-plugin/ (moves [Unreleased] -> [x.y.z])
+#   3. commit + merge to main
+#   4. run this workflow from the Actions tab
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build, sign and verify but do NOT upload to the Marketplace'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ij-plugin-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Point this at a GitHub Environment holding the four secrets below if you want
+    # required-reviewer protection on publishes. The secrets can also live at repo level.
+    # environment: marketplace
+    defaults:
+      run:
+        working-directory: ij-plugin
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Set up JDK
+        uses: actions/setup-java@v6
+        with:
+          java-version: 21
+          distribution: 'temurin'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          build-root-directory: ij-plugin
+          cache-read-only: true
+
+      - name: Verify plugin
+        run: ./gradlew verifyPlugin
+
+      - name: Build and sign plugin
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
+        run: ./gradlew buildPlugin signPlugin
+
+      - name: Upload signed plugin artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: alpaca-plugin-distribution
+          path: ij-plugin/build/distributions/*.zip
+
+      - name: Publish to JetBrains Marketplace
+        if: ${{ !inputs.dry_run }}
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
+        run: ./gradlew publishPlugin

--- a/.github/workflows/ij-plugin-test.yml
+++ b/.github/workflows/ij-plugin-test.yml
@@ -62,3 +62,33 @@ jobs:
           fail_ci_if_error: false
       - name: Build plugin
         run: ./gradlew buildPlugin
+
+  # Structural validation of plugin.xml / the plugin archive, plus the IntelliJ Plugin
+  # Verifier against the IDEs the platform recommends. Separate job: it downloads full
+  # IDE distributions and has nothing to do with the grammar-export test setup above.
+  verify:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ij-plugin
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Set up JDK
+        uses: actions/setup-java@v6
+        with:
+          java-version: 21
+          distribution: 'temurin'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          build-root-directory: ij-plugin
+          cache-read-only: true
+      - name: Verify plugin
+        run: ./gradlew verifyPlugin
+      - name: Upload verifier report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: plugin-verifier-report
+          path: ij-plugin/build/reports/pluginVerifier

--- a/docs/_docs/ide-plugin.md
+++ b/docs/_docs/ide-plugin.md
@@ -44,7 +44,11 @@ This env var is independent from `ALPACA_DEBUG_DIR` (see [Debug Settings](debug-
 
 ## Installing the plugin
 
-The plugin isn't published to the JetBrains Marketplace yet, so build it from source:
+Install **Alpaca** from the JetBrains Marketplace: in your IDE, open **Settings | Plugins | Marketplace**, search for "Alpaca", and click **Install**. It targets IDE builds 2025.2 and newer.
+
+### From source
+
+To build the current `main` yourself:
 
 ```bash
 cd ij-plugin
@@ -54,6 +58,8 @@ cd ij-plugin
 This produces a zip under `ij-plugin/build/distributions/`. Install it via **Settings | Plugins | ⚙️ | Install Plugin from Disk...** in your IDE.
 
 To try it out without installing anything permanently, run `./gradlew runIde` instead: it launches a disposable sandbox instance with the plugin already loaded.
+
+Maintainers: see [`ij-plugin/RELEASING.md`](https://github.com/halotukozak-com/alpaca/blob/main/ij-plugin/RELEASING.md) for the publishing workflow.
 
 ## Configuring
 

--- a/ij-plugin/CHANGELOG.md
+++ b/ij-plugin/CHANGELOG.md
@@ -1,0 +1,16 @@
+<!-- Keep a Changelog guide -> https://keepachangelog.com -->
+
+# Alpaca IntelliJ Plugin Changelog
+
+## [Unreleased]
+
+### Added
+
+- Initial release: IDE support for languages defined with the [Alpaca](https://github.com/halotukozak-com/alpaca) lexer/parser library, driven entirely by the grammar data Alpaca exports at compile time (`ALPACA_GRAMMAR_EXPORT_DIR`).
+- Syntax highlighting inferred from each token's regex shape.
+- A real PSI parser that drives the exported, conflict-resolved LR table; syntax errors surface as ordinary error annotations.
+- Structure View mirroring the parsed tree, one entry per grammar rule.
+- Code folding for any rule whose text spans more than one line.
+- Grammar-driven autocompletion of the fixed-spelling terminals valid at the caret.
+- Line comment toggling (`Ctrl+/`) for grammars that ignore a `prefix.*`-shaped rule.
+- Settings panel (**Settings | Tools | Alpaca**) for the grammar export directory and per-extension language mappings.

--- a/ij-plugin/LICENSE
+++ b/ij-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Bartłomiej Kozak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ij-plugin/RELEASING.md
+++ b/ij-plugin/RELEASING.md
@@ -1,0 +1,71 @@
+# Releasing the Alpaca IntelliJ plugin
+
+The plugin is published to the [JetBrains Marketplace](https://plugins.jetbrains.com/) from the
+[**Publish IntelliJ Plugin**](../.github/workflows/ij-plugin-publish.yml) workflow (`workflow_dispatch`, Actions tab).
+Everything below the one-time setup is the per-release checklist.
+
+## One-time setup
+
+### 1. Generate a signing certificate
+
+Marketplace strongly recommends signed plugins. Generate a self-issued chain once (see
+the [plugin signing docs](https://plugins.jetbrains.com/docs/intellij/plugin-signing.html)):
+
+```bash
+openssl genpkey -aes-256-cbc -algorithm RSA -out private.pem -pkeyopt rsa_keygen_bits:4096
+openssl req -key private.pem -new -x509 -days 3650 -out chain.crt \
+  -subj "/CN=Alpaca IntelliJ plugin/O=halotukozak"
+```
+
+Keep `private.pem`, its passphrase, and `chain.crt` somewhere safe (a password manager).
+
+### 2. Get a Marketplace token
+
+Marketplace → your profile → **My Tokens** → generate a permanent token scoped to plugin upload.
+
+### 3. Add the repository secrets
+
+`Settings → Secrets and variables → Actions` (or a `marketplace` Environment — see the commented
+`environment:` line in the workflow):
+
+| Secret                 | Value                             |
+|------------------------|-----------------------------------|
+| `PUBLISH_TOKEN`        | the Marketplace token from step 2 |
+| `CERTIFICATE_CHAIN`    | full contents of `chain.crt`      |
+| `PRIVATE_KEY`          | full contents of `private.pem`    |
+| `PRIVATE_KEY_PASSWORD` | the passphrase from step 1        |
+
+### 4. First upload (manual, once)
+
+`publishPlugin` can only *update* a plugin that already exists on the Marketplace. For the very first version, build it
+locally and upload by hand:
+
+```bash
+cd ij-plugin
+./gradlew buildPlugin           # -> build/distributions/alpaca-ij-plugin-<version>.zip
+```
+
+Upload that zip at <https://plugins.jetbrains.com/plugin/add>, fill in the listing, and wait for JetBrains moderation
+(usually a couple of business days). After it is approved and live, every later version goes through the workflow.
+
+## Per-release checklist
+
+1. Bump `version` in [`gradle.properties`](gradle.properties) (plain `x.y.z`, or `x.y.z-eap.N` /
+   `x.y.z-beta` for a pre-release channel).
+2. `cd ij-plugin && ./gradlew patchChangelog` — moves `[Unreleased]` in `CHANGELOG.md` to a
+   `[x.y.z]` section and reseeds an empty `[Unreleased]`. Review the diff.
+3. Commit both files, open a PR, merge to `main`.
+4. Actions tab → **Publish IntelliJ Plugin** → *Run workflow*. Leave `dry_run` off for a real publish; tick it to only
+   build + sign + verify.
+5. The workflow runs `verifyPlugin`, then `buildPlugin signPlugin`, uploads the signed zip as a run artifact, and
+   finally `publishPlugin`. Stable versions appear after a short re-moderation; pre-release channels are immediate but
+   only reach users who added the channel's repository URL.
+
+## Notes
+
+- `sinceBuild` is `252` (2025.2); `untilBuild` is intentionally open — the plugin only uses stable
+  `com.intellij.modules.platform` API. Bump `sinceBuild` only when adopting newer platform API.
+- The channel is derived from the version suffix in `build.gradle.kts`: no suffix → `default`
+  (stable), `-eap.1` → `eap`, `-beta` → `beta`.
+- CI (`ij-plugin-test.yml`) already runs `verifyPlugin` on every PR touching `ij-plugin/`, so a green PR means the
+  publish workflow's verification step will pass too.

--- a/ij-plugin/build.gradle.kts
+++ b/ij-plugin/build.gradle.kts
@@ -6,10 +6,20 @@ plugins {
     id("org.jetbrains.intellij.platform")
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
     id("org.jetbrains.kotlinx.kover") version "0.9.9"
+    id("org.jetbrains.changelog") version "2.5.0"
 }
 
 group = "com.halotukozak.alpaca.plugin"
-version = "0.1.0"
+
+// kotlin-stdlib (and its transitive `annotations:13.0`) ship with the IntelliJ Platform,
+// which also provides them on the compile classpath. Bundling our own copy in the plugin
+// zip is redundant and the Plugin Verifier flags a bundled stdlib.
+// `kotlin.stdlib.default.dependency=false` stops the Kotlin plugin adding one; this drops
+// the copy kotlinx-serialization pulls in transitively from the packaged runtime classpath
+// only (not the platform's own resolution, which genuinely needs it).
+configurations.runtimeClasspath {
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+}
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
@@ -30,5 +40,51 @@ intellijPlatform {
         id = "com.halotukozak.alpaca.plugin"
         name = "Alpaca"
         version = project.version.toString()
+
+        ideaVersion {
+            // 252 == 2025.2, the platform this plugin builds against. The plugin only
+            // touches stable `com.intellij.modules.platform` API, so it is not pinned
+            // to an upper IDE build -- leave untilBuild open-ended.
+            sinceBuild = "252"
+            untilBuild = provider { null }
+        }
+
+        // changeNotes is wired automatically from CHANGELOG.md by the changelog plugin:
+        // the section matching `version` above, or the "[Unreleased]" section before a
+        // release has been cut.
     }
+
+    // `signPlugin` and `publishPlugin` read their credentials from the environment:
+    //   PUBLISH_TOKEN        - JetBrains Marketplace token (Marketplace > My Tokens)
+    //   CERTIFICATE_CHAIN    - PEM chain for the signing certificate
+    //   PRIVATE_KEY          - PEM private key matching the chain
+    //   PRIVATE_KEY_PASSWORD - passphrase for PRIVATE_KEY
+    // See https://plugins.jetbrains.com/docs/intellij/plugin-signing.html
+    signing {
+        certificateChain = providers.environmentVariable("CERTIFICATE_CHAIN")
+        privateKey = providers.environmentVariable("PRIVATE_KEY")
+        password = providers.environmentVariable("PRIVATE_KEY_PASSWORD")
+    }
+
+    publishing {
+        token = providers.environmentVariable("PUBLISH_TOKEN")
+        // Version suffix -> release channel: `0.1.0` publishes to the stable channel,
+        // `0.2.0-eap.1` / `0.2.0-beta` publish to a matching pre-release channel that
+        // users must opt into by adding a custom plugin repository URL.
+        val channel = project.version.toString().substringAfter('-', "").substringBefore('.').ifEmpty { "default" }
+        channels = listOf(channel)
+    }
+
+    pluginVerification {
+        ides {
+            recommended()
+        }
+    }
+}
+
+changelog {
+    // Powers the "compare" links patchChangelog writes into CHANGELOG.md. Tags in this
+    // repo are the Scala library's (`v*`); the plugin has no tags of its own, so these
+    // links point at the repo tree rather than plugin-specific diffs.
+    repositoryUrl = "https://github.com/halotukozak-com/alpaca"
 }

--- a/ij-plugin/build.gradle.kts
+++ b/ij-plugin/build.gradle.kts
@@ -71,7 +71,12 @@ intellijPlatform {
         // Version suffix -> release channel: `0.1.0` publishes to the stable channel,
         // `0.2.0-eap.1` / `0.2.0-beta` publish to a matching pre-release channel that
         // users must opt into by adding a custom plugin repository URL.
-        val channel = project.version.toString().substringAfter('-', "").substringBefore('.').ifEmpty { "default" }
+        val channel =
+            project.version
+                .toString()
+                .substringAfter('-', "")
+                .substringBefore('.')
+                .ifEmpty { "default" }
         channels = listOf(channel)
     }
 

--- a/ij-plugin/gradle.properties
+++ b/ij-plugin/gradle.properties
@@ -2,3 +2,10 @@ kotlin.stdlib.default.dependency = false
 
 org.gradle.configuration-cache = true
 org.gradle.caching = true
+
+# Single source of truth for the plugin version. Gradle picks this up as the project
+# version automatically; the IntelliJ Platform Gradle Plugin derives the plugin
+# descriptor's <version> from it, and the changelog plugin keys its section off it.
+# Release flow: bump this, run `./gradlew patchChangelog`, commit, then run the
+# "Publish IntelliJ Plugin" workflow.
+version = 0.1.0

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,9 +1,31 @@
 <idea-plugin>
   <id>com.halotukozak.alpaca.plugin</id>
   <name>Alpaca</name>
-  <vendor>halotukozak</vendor>
+  <vendor url="https://github.com/halotukozak-com/alpaca">halotukozak</vendor>
   <description><![CDATA[
-    IDE support for languages defined with the <a href="https://github.com/halotukozak/alpaca">Alpaca</a> lexer/parser library.
+    <p>
+      IDE support for custom languages defined with the
+      <a href="https://github.com/halotukozak-com/alpaca">Alpaca</a> lexer/parser library for Scala.
+    </p>
+    <p>
+      An Alpaca-defined language is just Scala code, with no separate grammar file to point an IDE at.
+      This plugin reads the grammar data your <code>lexer{...}</code>/<code>parser</code> macros already
+      compute, exported to disk at compile time, and turns it into a working custom language in the IDE
+      for any language you define, without writing any plugin code yourself.
+    </p>
+    <ul>
+      <li><b>Syntax highlighting</b> inferred from each token's regex shape.</li>
+      <li><b>A real parser</b> that drives your grammar's exact, conflict-resolved LR table and reports
+        syntax errors as ordinary red squiggles.</li>
+      <li><b>Structure View</b> and <b>code folding</b> that mirror the parsed tree.</li>
+      <li><b>Autocompletion</b> of the fixed-spelling terminals valid at the caret.</li>
+      <li><b>Line comment toggling</b> for grammars with a <code>prefix.*</code>-shaped ignored rule.</li>
+    </ul>
+    <p>
+      Point <b>Settings | Tools | Alpaca</b> at your grammar export directory and map file extensions
+      to grammars. See the <a href="https://halotukozak-com.github.io/alpaca/docs/ide-plugin.html">documentation</a>
+      for details.
+    </p>
   ]]></description>
 
   <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
Wires up everything needed to release `ij-plugin/` to the JetBrains Marketplace. Follow-up to the plugin CI branch (#530).

## Build config (`ij-plugin/build.gradle.kts`, `gradle.properties`)

- Apply `org.jetbrains.changelog` 2.5.0. `changeNotes` in the built `plugin.xml` is now sourced from `CHANGELOG.md` (the `[Unreleased]` section until a release is cut, then the matching `[x.y.z]` section).
- `signing` / `publishing` blocks read credentials from the environment (`PUBLISH_TOKEN`, `CERTIFICATE_CHAIN`, `PRIVATE_KEY`, `PRIVATE_KEY_PASSWORD`).
- `pluginVerification { ides { recommended() } }`.
- `ideaVersion`: `sinceBuild = 252`, `untilBuild` left open — the plugin only touches stable `com.intellij.modules.platform` API.
- Version moved to `gradle.properties` as the single source of truth; the Marketplace release channel is derived from its suffix (`0.1.0` → stable, `0.2.0-eap.1` → `eap`, `0.2.0-beta` → `beta`).
- **Drop the bundled `kotlin-stdlib`** (and its transitive `annotations:13.0`) from the plugin zip — the platform provides them and the Plugin Verifier flags a bundled stdlib. Zip goes from 6 jars / 2.6 MB to 4 jars / 0.8 MB.

## CI

- `ij-plugin-test.yml`: new `verify` job running `./gradlew verifyPlugin` on every PR touching `ij-plugin/`, uploading the verifier report.
- `ij-plugin-publish.yml` (new): manual `workflow_dispatch` with a `dry_run` toggle. Runs `verifyPlugin`, then `buildPlugin signPlugin`, uploads the signed zip as a run artifact, then `publishPlugin`. Manual-only because the repo's `v*` tags already drive the Scala library's Sonatype publish and any tag drives the docs deploy.

## Docs / metadata

- `ij-plugin/CHANGELOG.md`, `ij-plugin/RELEASING.md` (one-time setup + per-release checklist).
- `ij-plugin/LICENSE`: copy of the repo's MIT license, so the standalone plugin zip carries its own license text. Marketplace listing should also select "MIT".
- `plugin.xml`: richer `<description>` (Marketplace needs meaningful HTML), `vendor url`.
- `docs/_docs/ide-plugin.md`: Marketplace install as the primary path, from-source build kept as an alternative.

## Validated locally

- `./gradlew test buildPlugin` green (with grammars exported via `./mill jvm.test.compile` as CI does).
- Built `plugin.xml` confirmed: `since-build="252"`, no `until-build`, `<change-notes>` injected from the changelog.
- `verifyPluginProjectConfiguration` / `verifyPluginStructure` clean.
- Full `verifyPlugin` not run locally (downloads full IDEs, times out) — it runs in CI.

## Not done here

- First Marketplace upload is manual (`publishPlugin` can only *update* an existing plugin) — see `RELEASING.md`.
- Bundling `LICENSE` *inside* the plugin zip: skipped to keep the packaging config minimal; can add later if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)