### PR TITLE
docs: restructure sidebar sections and fix formatting inconsistencies

### DIFF
--- a/docs/_docs/cookbook/index.md
+++ b/docs/_docs/cookbook/index.md
@@ -1,0 +1,10 @@
+# Cookbook
+
+Complete, self-contained examples that put the reference pages to work. Each recipe builds one working language end to end — lexer, parser, and evaluation — and calls out the Alpaca features it leans on.
+
+- **[Expression Evaluator](expression-evaluator.md)** — a math evaluator with arithmetic, exponentiation, unary minus, parentheses, constants, and functions. Focus: operator precedence and the `before`/`after` conflict-resolution DSL.
+- **[JSON Parser](json-parser.md)** — objects, arrays, strings, numbers, booleans, and null. Focus: recursive rules, separator-delimited lists, backtick-quoted token names.
+- **[Contextual Lexing](contextual-lexing.md)** — stateful tokenization: nesting depth, counters, lexer-to-parser hand-off, graceful errors. Focus: custom `LexerCtx`/`ParserCtx`, tracking fragments, `ErrorHandling`.
+- **[BrainFuck Interpreter](brainfuck-interpreter.md)** — the full BrainFuck> interpreter built incrementally through the rest of the docs, assembled in one place. Combines every feature above.
+
+New to Alpaca? Start with [Getting Started](../getting-started.md), which walks through the BrainFuck interpreter step by step.

--- a/docs/_docs/debug-settings.md
+++ b/docs/_docs/debug-settings.md
@@ -7,11 +7,14 @@ When you define a `Parser`, Alpaca can dump the generated grammar tables to disk
 Set the `ALPACA_DEBUG_DIR` environment variable to an absolute directory path before compiling. If it's unset (the default), nothing is written.
 
 ```bash
-ALPACA_DEBUG_DIR=/absolute/path/to/debug ./mill jvm.compile
-```
+# Mill
+ALPACA_DEBUG_DIR=$(pwd)/debug ./mill jvm.compile
 
-```bash
+# sbt
 ALPACA_DEBUG_DIR=$(pwd)/debug sbt compile
+
+# Scala CLI
+ALPACA_DEBUG_DIR=$(pwd)/debug scala-cli compile .
 ```
 
 The directory is created automatically if it doesn't exist.
@@ -19,7 +22,7 @@ The directory is created automatically if it doesn't exist.
 <details>
 <summary>Under the hood</summary>
 
-The directory is read via `sys.env` at macro-expansion time, inside the `parser` macro's implementation. Mill and sbt both run compilation in a JVM that inherits the environment of the process that launched it -- but if you're using a persistent build-tool daemon (e.g. Mill's), the daemon captured its environment when *it* started, not when you last ran a build command. If setting the variable doesn't seem to take effect, restart the daemon (`mill --no-daemon ...` for one-off invocations, or kill the running daemon process) and retry.
+The directory is read via `sys.env` at macro-expansion time, inside the `parser` macro's implementation. Mill, sbt, and Scala CLI all run compilation in a JVM that inherits the environment of the process that launched it -- but if you're using a persistent build-tool daemon (e.g. Mill's, or an interactive `sbt` shell), the daemon captured its environment when *it* started, not when you last ran a build command. If setting the variable doesn't seem to take effect, restart the daemon (`mill --no-daemon ...` for one-off invocations, or kill the running daemon process) and retry.
 
 </details>
 

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -264,4 +264,4 @@ This BrainFuck interpreter uses the simplest form of every Alpaca feature. The r
 - [Parser Context](parser-context.md) — shared state during parsing (we add a function registry)
 - [Extractors](extractors.md) — pattern matching on terminals and non-terminals
 - [Conflict Resolution](conflict-resolution.md) — resolving shift/reduce and reduce/reduce conflicts
-- [Theory](theory/pipeline.md) — formal foundations behind everything above
+- [Theory](theory/index.md) — formal foundations behind everything above

--- a/docs/_docs/ide-plugin.md
+++ b/docs/_docs/ide-plugin.md
@@ -27,8 +27,17 @@ The parser is a hand-written shift-reduce driver that follows the exported table
 Set the `ALPACA_GRAMMAR_EXPORT_DIR` environment variable to an absolute directory path before compiling. If it's unset (the default), nothing is written, and there is no runtime cost or effect on the compiled artifact either way.
 
 ```bash
-ALPACA_GRAMMAR_EXPORT_DIR=/absolute/path/to/export ./mill jvm.compile
+# Mill
+ALPACA_GRAMMAR_EXPORT_DIR=$(pwd)/export ./mill jvm.compile
+
+# sbt
+ALPACA_GRAMMAR_EXPORT_DIR=$(pwd)/export sbt compile
+
+# Scala CLI
+ALPACA_GRAMMAR_EXPORT_DIR=$(pwd)/export scala-cli compile .
 ```
+
+The variable is read from the environment (`sys.env`) at macro-expansion time, so any tool that shells out to the Scala 3 compiler behaves the same way. If you use a persistent build daemon — Mill's, or an interactive `sbt` shell — it captured its environment when it started: set the variable before launching the daemon, or restart it (`mill --no-daemon ...`, a fresh `sbt` session) after setting it.
 
 For every `lexer{...}`/`object MyParser extends Parser`, Alpaca writes:
 

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -129,7 +129,7 @@ println(result) // 14.0
 - **[Getting Started](getting-started.md)** — build a BrainFuck interpreter step by step
 - **[Lexer](lexer.md)** — the full lexer DSL reference
 - **[Parser](parser.md)** — grammar rules, EBNF operators, conflict resolution
-- **[Theory](theory/pipeline.md)** — formal foundations: finite automata, LR parsing, parse tables
+- **[Theory](theory/index.md)** — formal foundations: finite automata, LR parsing, parse tables
 
 ## Benchmarks
 

--- a/docs/_docs/theory/cfg.md
+++ b/docs/_docs/theory/cfg.md
@@ -1,3 +1,5 @@
+# Context-Free Grammars
+
 Context-free grammars are the backbone of syntactic analysis. A grammar defines a language by specifying how symbols can
 be combined and rewritten — "context-free" means each rule applies regardless of surrounding context. If the lexer is
 the vocabulary of a language, the grammar is its syntax.

--- a/docs/_docs/theory/conflicts.md
+++ b/docs/_docs/theory/conflicts.md
@@ -1,3 +1,5 @@
+# Conflicts and Disambiguation
+
 A grammar is ambiguous if a string can be parsed in more than one way. In LR parsing, ambiguity manifests as a conflict: the parse table has two valid entries for the same (state, symbol) pair, and the parser cannot proceed deterministically.
 
 ## What is a Parse Table Conflict?
@@ -30,7 +32,6 @@ Expr PLUS ($plus) Expr PLUS ($plus) ...
 Consider marking production Expr -> Expr PLUS ($plus) Expr to be before or after "PLUS ($plus)"
 ```
 
-
 ## Reduce/Reduce Conflicts
 
 A reduce/reduce conflict occurs when two different productions can reduce the same token sequence with the same lookahead. The parser has two Reduce entries for the same (state, t) pair and cannot decide which to apply.
@@ -43,7 +44,6 @@ In situation like:
 Number ...
 Consider marking one of the productions to be before or after the other
 ```
-
 
 Reduce/reduce conflicts are less common than shift/reduce conflicts. They typically indicate a grammar design issue — two rules competing for the same token sequence. The usual fix is to restructure the grammar so the two competing productions have distinct right-hand sides, or to use a different non-terminal.
 

--- a/docs/_docs/theory/full-example.md
+++ b/docs/_docs/theory/full-example.md
@@ -1,3 +1,5 @@
+# Full Calculator Example
+
 The preceding theory pages have built up each component of the compiler pipeline: tokens and lexical analysis, context-free grammars, LR parsing mechanics, conflict resolution, and semantic actions. This page assembles all the pieces into a working arithmetic calculator — the same grammar used throughout the tutorial, now fully resolved and evaluating. Follow the steps below from grammar definition to the evaluated result `7.0`.
 
 ## Step 1: The Lexer

--- a/docs/_docs/theory/index.md
+++ b/docs/_docs/theory/index.md
@@ -1,0 +1,24 @@
+# Theory
+
+A tutorial on the compiler-construction theory behind Alpaca: what a lexer and parser actually are, how regular expressions become finite automata, how context-free grammars drive LR parsing, and where conflicts, ambiguity, and error recovery come from.
+
+You don't need any of this to use the library — the [reference pages](../lexer.md) and the [Cookbook](../cookbook/index.md) are enough to build a language. Read this section when you want to understand *why* a grammar has a conflict, what the generated parse table means, or how the pieces fit together formally.
+
+Start with **[The Compilation Pipeline](pipeline.md)** for the mental model everything else builds on, then follow the chapters in order:
+
+- **[The Compilation Pipeline](pipeline.md)** — the four stages from source text to typed result
+- **[Tokens and Lexemes](tokens.md)** — token classes vs. instances, and how Alpaca represents them
+- **[The Lexer: Regex to Finite Automata](lexer-fa.md)** — compiling regular expressions
+- **[Regular vs Context-Free](regular-vs-context-free.md)** — why lexing and parsing are separate problems
+- **[Context-Free Grammars](cfg.md)** — productions, derivations, parse trees
+- **[EBNF and Extended Notations](ebnf-extended-notations.md)** — repetition and optionality operators
+- **[The Shift-Reduce Loop](shift-reduce.md)** — the core parsing algorithm
+- **[Why LR Parsing](why-lr.md)** — the trade-offs behind Alpaca's choice
+- **[Conflicts and Disambiguation](conflicts.md)** — shift/reduce and reduce/reduce
+- **[Semantic Actions](semantic-actions.md)** — attaching meaning to reductions
+- **[AST Construction Patterns](ast-construction.md)** — shaping the output tree
+- **[Operator Precedence Grammars](operator-precedence.md)** — encoding precedence and associativity
+- **[Ambiguity](ambiguity.md)** — grammars with more than one parse
+- **[Error Recovery Theory](error-recovery-theory.md)** — continuing past a syntax error
+- **[Attribute Grammars](attribute-grammars.md)** — the formal model behind semantic actions
+- **[Full Calculator Example](full-example.md)** — every concept in one worked grammar

--- a/docs/_docs/theory/semantic-actions.md
+++ b/docs/_docs/theory/semantic-actions.md
@@ -1,3 +1,5 @@
+# Semantic Actions
+
 A parser recognizes whether an input string belongs to a grammar — it accepts or rejects. But most programs need to *compute* something from the input, not just verify it. Semantic actions bridge structure and computation: they attach a computation to each production rule, so that the parser produces a typed value as a direct outcome of parsing, rather than a parse tree.
 
 ## Syntax-Directed Translation

--- a/docs/_docs/theory/shift-reduce.md
+++ b/docs/_docs/theory/shift-reduce.md
@@ -1,3 +1,5 @@
+# The Shift-Reduce Loop
+
 The shift-reduce loop is the heart of LR parsing. Every LR parser — regardless of whether it uses LR(0), LALR(1), or full LR(1) lookahead — executes the same fundamental loop: shift the next token onto a stack, or reduce the top of the stack to a non-terminal. This page traces that loop step by step for a concrete input.
 
 ## The Parse Stack

--- a/docs/_docs/theory/tokens.md
+++ b/docs/_docs/theory/tokens.md
@@ -103,7 +103,6 @@ The `BrainLexer` running example defines these token classes:
 
 `functionName` is the only value-bearing token: the `@` binding captures the matched text and passes it to `Token["functionName"](name)`. The other tokens use `Token["NAME"]` without a value argument — they carry `Unit`. Their presence in the stream is enough; the matched text is accessible via `lexeme.text` from the context snapshot if needed.
 
-
 ## Cross-links
 
 - See [Lexer](../lexer.md) for the full `lexer` DSL reference and all token forms.

--- a/docs/_docs/theory/why-lr.md
+++ b/docs/_docs/theory/why-lr.md
@@ -1,3 +1,5 @@
+# Why LR Parsing
+
 Not every parsing strategy handles every grammar. Top-down parsers are intuitive but stumble on the natural structure of
 arithmetic expressions. LR parsing was developed specifically to handle the grammars that arise in practice — including
 left-recursive grammars like the one that drives CalcParser.

--- a/docs/_docs/tooling.md
+++ b/docs/_docs/tooling.md
@@ -1,0 +1,13 @@
+# Tooling
+
+Alpaca's macros already compute everything there is to know about your grammar at compile time — the token patterns, the productions, the resolved LR table. Two environment variables let you pull that information out, for two different audiences:
+
+| Variable | Writes | For |
+|---|---|---|
+| `ALPACA_DEBUG_DIR` | The constructed parse tables, action table, and conflict-resolution table | You, to understand or debug a grammar |
+| `ALPACA_GRAMMAR_EXPORT_DIR` | The grammar's *shape* (tokens, productions, table) as JSON | Tools that consume grammars, chiefly the IntelliJ plugin |
+
+Both are read from the environment at macro-expansion time, do nothing when unset, and have no runtime cost or effect on the compiled artifact. Both work with any build tool that runs the Scala 3 compiler — the linked pages show Mill, sbt, and Scala CLI.
+
+- **[Debug Settings](debug-settings.md)** — dump the LR automaton and conflict-resolution tables to disk during compilation, to see why a grammar has a conflict or what automaton Alpaca built.
+- **[IntelliJ Plugin](ide-plugin.md)** — turn any Alpaca-defined language into a real custom language in the IDE, with syntax highlighting, real parsing, autocompletion, structure view, and code folding — no per-language plugin code.

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -21,13 +21,17 @@ subsection:
       - title: Conflict Resolution
         page: conflict-resolution.md
   - title: Tooling
-    index: debug-settings.md
+    index: tooling.md
     subsection:
+      - title: Debug Settings
+        page: debug-settings.md
       - title: IntelliJ Plugin
         page: ide-plugin.md
   - title: Cookbook
-    index: cookbook/expression-evaluator.md
+    index: cookbook/index.md
     subsection:
+      - title: Expression Evaluator
+        page: cookbook/expression-evaluator.md
       - title: JSON Parser
         page: cookbook/json-parser.md
       - title: Contextual Lexing
@@ -35,8 +39,10 @@ subsection:
       - title: BrainFuck Interpreter
         page: cookbook/brainfuck-interpreter.md
   - title: Theory
-    index: theory/pipeline.md
+    index: theory/index.md
     subsection:
+      - title: The Compilation Pipeline
+        page: theory/pipeline.md
       - title: Tokens and Lexemes
         page: theory/tokens.md
       - title: "The Lexer: Regex to Finite Automata"


### PR DESCRIPTION
## Why

Two issues raised about the docs:

1. Clicking the **Tooling** sidebar section opened the *Debug Settings* page, and there was no separate entry for debugging — the section title and its landing content didn't match, and one of its two pages had no nav entry of its own.
2. The **IntelliJ Plugin** page only showed how to set `ALPACA_GRAMMAR_EXPORT_DIR` with Mill, nothing about sbt or Scala CLI.

While fixing those I audited formatting across all of `docs/_docs/` and folded in the clear inconsistencies.

## Changes

### Sidebar navigation
- **Tooling**: new `tooling.md` overview page as the section landing; `Debug Settings` and `IntelliJ Plugin` are now both explicit sub-entries.
- **Cookbook**: new `cookbook/index.md` overview; `Expression Evaluator` is now an explicit entry instead of the silent landing page.
- **Theory**: new `theory/index.md` overview; `The Compilation Pipeline` is now an explicit entry. `index.md` / `getting-started.md` "What's Next" links repointed to `theory/index.md`.

Lexer and Parser were left alone — there the section title already matches the landing page's `# H1`.

### Build-tool coverage
- `ide-plugin.md`: `ALPACA_GRAMMAR_EXPORT_DIR` examples for Mill, sbt, and Scala CLI, plus a note about persistent build daemons capturing their environment at start.
- `debug-settings.md`: added the Scala CLI example for parity; mention Scala CLI in the daemon note.

### Formatting
- Added missing `# H1` titles to 6 Theory pages: `cfg`, `conflicts`, `full-example`, `semantic-actions`, `shift-reduce`, `why-lr` (they started straight into prose; every other page has one).
- Removed stray double blank lines in `conflicts.md` and `tokens.md`.

## Verified
- `./mill jvm.docJar` builds clean (only the 3 pre-existing scaladoc member-link warnings in `lexer.scala`).
- New pages render with correct titles; sidebar links resolve.

## Not included (noted for a follow-up)
`theory/lexer-fa.md` and `theory/why-lr.md` (and partly `theory/cfg.md`) are hard-wrapped at ~95–120 chars while the other ~30 pages keep one line per paragraph. Left as-is since it's a house-style call, not a clear bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)