### PR TITLE
Add grammar-aware brace matching

### DIFF
--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighter.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighter.kt
@@ -22,15 +22,24 @@ class AlpacaBraceHighlighter : HeavyBraceHighlighter() {
         offset: Int,
     ): Boolean = psiFile.language == AlpacaLanguage
 
-    override fun matchBrace(
+    // Widened from the superclass's `protected` so AlpacaBraceHighlighterTest can call it directly
+    // instead of going through the platform's background-highlighting machinery.
+    public override fun matchBrace(
         psiFile: PsiFile,
         offset: Int,
     ): Pair<TextRange, TextRange>? {
         val virtualFile = psiFile.virtualFile ?: psiFile.originalFile.virtualFile ?: return null
         val resolved = GrammarService.getInstance(psiFile.project).resolveForFile(virtualFile) ?: return null
 
+        // Match against the editor document's text, not psiFile.text: the caller highlights the
+        // returned ranges against the document, and while an edit is uncommitted the PSI can still
+        // hold the pre-edit (longer) text, which would put our offsets past the document's end.
+        val text = psiFile.viewProvider.document?.immutableCharSequence ?: return null
+        if (offset > text.length) return null
+
         val (open, close) =
-            AlpacaBraceScanner.matchAt(psiFile.text, resolved.lexerId, resolved.tokens, offset) ?: return null
+            AlpacaBraceScanner.matchAt(text, resolved.lexerId, resolved.tokens, offset) ?: return null
+        if (open.endOffset > text.length || close.endOffset > text.length) return null
         return Pair.create(open, close)
     }
 }

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighter.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighter.kt
@@ -1,0 +1,36 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.grammar.GrammarService
+import com.halotukozak.alpaca.plugin.lexer.AlpacaLanguage
+import com.intellij.codeInsight.highlighting.HeavyBraceHighlighter
+import com.intellij.openapi.util.Pair
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+
+/**
+ * Brace matching for Alpaca-defined languages. Which tokens are brackets, and which open/close,
+ * depends on the file's grammar — not known to a plain [com.intellij.lang.PairedBraceMatcher],
+ * whose `getPairs()` takes no context. [HeavyBraceHighlighter] instead gets the file and caret
+ * offset, so the grammar can be resolved and [AlpacaBraceScanner] run against it.
+ *
+ * The scan lexes the whole file; it runs in a background read action, and the languages Alpaca
+ * targets are small, so that is fine.
+ */
+class AlpacaBraceHighlighter : HeavyBraceHighlighter() {
+    override fun isAvailable(
+        psiFile: PsiFile,
+        offset: Int,
+    ): Boolean = psiFile.language == AlpacaLanguage
+
+    override fun matchBrace(
+        psiFile: PsiFile,
+        offset: Int,
+    ): Pair<TextRange, TextRange>? {
+        val virtualFile = psiFile.virtualFile ?: psiFile.originalFile.virtualFile ?: return null
+        val resolved = GrammarService.getInstance(psiFile.project).resolveForFile(virtualFile) ?: return null
+
+        val (open, close) =
+            AlpacaBraceScanner.matchAt(psiFile.text, resolved.lexerId, resolved.tokens, offset) ?: return null
+        return Pair.create(open, close)
+    }
+}

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceScanner.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceScanner.kt
@@ -1,0 +1,114 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.grammar.BracketKind
+import com.halotukozak.alpaca.plugin.grammar.BracketRole
+import com.halotukozak.alpaca.plugin.grammar.TokenSpec
+import com.halotukozak.alpaca.plugin.grammar.bracketRoleOf
+import com.halotukozak.alpaca.plugin.lexer.ALPACA_BAD_CHARACTER
+import com.halotukozak.alpaca.plugin.lexer.AlpacaLexer
+import com.halotukozak.alpaca.plugin.lexer.AlpacaTokenTypes
+import com.intellij.openapi.util.TextRange
+
+/**
+ * Grammar-agnostic brace matching: lexes text with a grammar's own [AlpacaLexer], keeps the tokens
+ * whose pattern is a single `(` `)` `[` `]` `{` `}` (so brackets inside string/comment tokens are
+ * ignored), and pairs them by nesting. Pure — no PSI or platform services — so it is unit-testable
+ * and [AlpacaBraceHighlighter] is a thin wrapper over it.
+ */
+object AlpacaBraceScanner {
+    private class Bracket(
+        val range: TextRange,
+        val role: BracketRole,
+    )
+
+    /**
+     * The opening/closing brace pair (opening first) touching [caretOffset] — the bracket that
+     * starts at the caret, or failing that the one that ends at it — or null if there is no bracket
+     * there or it has no well-nested match.
+     */
+    fun matchAt(
+        text: CharSequence,
+        lexerId: String,
+        tokenSpecs: List<TokenSpec>,
+        caretOffset: Int,
+    ): Pair<TextRange, TextRange>? {
+        val brackets = collectBrackets(text, lexerId, tokenSpecs)
+        if (brackets.isEmpty()) return null
+
+        val targetIndex =
+            brackets
+                .indexOfFirst { it.range.startOffset == caretOffset }
+                .takeIf { it >= 0 }
+                ?: brackets.indexOfFirst { it.range.endOffset == caretOffset }.takeIf { it >= 0 }
+                ?: return null
+
+        val target = brackets[targetIndex]
+        val matchIndex = if (target.role.opening) matchForward(brackets, targetIndex) else matchBackward(brackets, targetIndex)
+        val match = matchIndex?.let(brackets::get) ?: return null
+
+        return if (target.role.opening) target.range to match.range else match.range to target.range
+    }
+
+    private fun collectBrackets(
+        text: CharSequence,
+        lexerId: String,
+        tokenSpecs: List<TokenSpec>,
+    ): List<Bracket> {
+        val roleByType =
+            tokenSpecs
+                .mapNotNull { spec -> bracketRoleOf(spec.pattern)?.let { AlpacaTokenTypes.forName(lexerId, spec.name) to it } }
+                .toMap()
+        if (roleByType.isEmpty()) return emptyList()
+
+        val lexer = AlpacaLexer(lexerId, tokenSpecs)
+        lexer.start(text, 0, text.length, 0)
+
+        val brackets = mutableListOf<Bracket>()
+        while (true) {
+            val type = lexer.tokenType ?: break
+            if (type != ALPACA_BAD_CHARACTER) {
+                roleByType[type]?.let { role -> brackets += Bracket(TextRange(lexer.tokenStart, lexer.tokenEnd), role) }
+            }
+            lexer.advance()
+        }
+        return brackets
+    }
+
+    /** Index of the closer that balances the opener at [openerIndex], or null if the run isn't well nested. */
+    private fun matchForward(
+        brackets: List<Bracket>,
+        openerIndex: Int,
+    ): Int? {
+        val stack = ArrayDeque<BracketKind>()
+        stack.addLast(brackets[openerIndex].role.kind)
+        for (i in openerIndex + 1 until brackets.size) {
+            val role = brackets[i].role
+            if (role.opening) {
+                stack.addLast(role.kind)
+            } else {
+                if (stack.removeLastOrNull() != role.kind) return null
+                if (stack.isEmpty()) return i
+            }
+        }
+        return null
+    }
+
+    /** Mirror of [matchForward] for a closer at [closerIndex]. */
+    private fun matchBackward(
+        brackets: List<Bracket>,
+        closerIndex: Int,
+    ): Int? {
+        val stack = ArrayDeque<BracketKind>()
+        stack.addLast(brackets[closerIndex].role.kind)
+        for (i in closerIndex - 1 downTo 0) {
+            val role = brackets[i].role
+            if (!role.opening) {
+                stack.addLast(role.kind)
+            } else {
+                if (stack.removeLastOrNull() != role.kind) return null
+                if (stack.isEmpty()) return i
+            }
+        }
+        return null
+    }
+}

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/PatternShape.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/PatternShape.kt
@@ -28,6 +28,28 @@ fun literalTextOf(pattern: String): String? {
     return text.toString()
 }
 
+/** One of the three bracket shapes a single-character token can denote. */
+enum class BracketKind { PARENTHESIS, BRACKET, BRACE }
+
+/** A bracket token's [kind] and whether it is the opening (`(` `[` `{`) or closing (`)` `]` `}`) side. */
+data class BracketRole(
+    val kind: BracketKind,
+    val opening: Boolean,
+)
+
+/** The [BracketRole] [pattern] denotes if it matches exactly one of `( ) [ ] { }` (bare or
+ *  escaped), or null for anything else. */
+fun bracketRoleOf(pattern: String): BracketRole? =
+    when (literalTextOf(pattern)?.singleOrNull()) {
+        '(' -> BracketRole(BracketKind.PARENTHESIS, opening = true)
+        ')' -> BracketRole(BracketKind.PARENTHESIS, opening = false)
+        '[' -> BracketRole(BracketKind.BRACKET, opening = true)
+        ']' -> BracketRole(BracketKind.BRACKET, opening = false)
+        '{' -> BracketRole(BracketKind.BRACE, opening = true)
+        '}' -> BracketRole(BracketKind.BRACE, opening = false)
+        else -> null
+    }
+
 /**
  * The fixed prefix [pattern] denotes for "prefix, then anything to end of line" (`#.*`, `//.*`,
  * ...), the shape Alpaca grammars typically use for line comments among their `ignored` rules.

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -41,6 +41,7 @@
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.lexer.AlpacaSyntaxHighlighterFactory"/>
     <colorSettingsPage implementation="com.halotukozak.alpaca.plugin.lexer.AlpacaColorSettingsPage"/>
+    <heavyBracesHighlighter implementation="com.halotukozak.alpaca.plugin.editing.AlpacaBraceHighlighter"/>
     <lang.parserDefinition
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.parser.AlpacaParserDefinition"/>

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighterTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighterTest.kt
@@ -1,0 +1,58 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.lexer.AlpacaFileTypeRegistrar
+import com.halotukozak.alpaca.plugin.settings.AlpacaSettingsState
+import com.halotukozak.alpaca.plugin.settings.GrammarAssociation
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+private const val LEXER_ID = "MathTest.CalcLexer@L11"
+private const val PARSER_ID = "MathTest.MathParser@L39"
+
+/**
+ * Regression coverage for [AlpacaBraceHighlighter.matchBrace]: it must match against the editor
+ * document, not `psiFile.text`, or it can hand the platform a [TextRange] past the document's
+ * current end -- exactly the crash `BackgroundHighlighter` hit mid-edit ("Invalid offsets:
+ * start=210; end=211; document length=210"), because `psiFile.text` can still reflect a longer,
+ * pre-edit version of the file while the corresponding PSI commit hasn't run yet.
+ */
+class AlpacaBraceHighlighterTest : BasePlatformTestCase() {
+    private val highlighter = AlpacaBraceHighlighter()
+
+    override fun setUp() {
+        super.setUp()
+        val settings = AlpacaSettingsState.getInstance(project)
+        settings.exportDirectory = "/tmp/alpaca-grammar-export"
+        settings.associations =
+            mutableListOf(GrammarAssociation(extension = "calc", lexerGrammarId = LEXER_ID, parserGrammarId = PARSER_ID))
+        runWriteAction { AlpacaFileTypeRegistrar.ensureRegistered("calc", LEXER_ID) }
+    }
+
+    fun `test matches a paren pair once the document is committed`() {
+        val file = myFixture.configureByText("test.calc", "(1+2)")
+
+        val match = highlighter.matchBrace(file, 0)
+
+        assertEquals(TextRange(0, 1), match?.first)
+        assertEquals(TextRange(4, 5), match?.second)
+    }
+
+    fun `test never matches past the document end while an edit is uncommitted`() {
+        val file = myFixture.configureByText("test.calc", "(1+2)")
+        val document = myFixture.editor.document
+
+        // Shrink the document directly, without committing PSI: psiFile.text (and the PSI tree)
+        // still reflects the old, longer text -- the same staleness BackgroundHighlighter can see
+        // mid-keystroke, before the commit that normally follows a real edit.
+        WriteCommandAction.runWriteCommandAction(project) { document.deleteString(4, 5) }
+        assertFalse(PsiDocumentManager.getInstance(project).isCommitted(document))
+
+        val match = highlighter.matchBrace(file, document.textLength)
+
+        assertTrue((match?.first?.endOffset ?: 0) <= document.textLength)
+        assertTrue((match?.second?.endOffset ?: 0) <= document.textLength)
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceScannerTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceScannerTest.kt
@@ -1,0 +1,83 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.grammar.TokenSpec
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AlpacaBraceScannerTest {
+    private val tokens =
+        listOf(
+            TokenSpec("ws", "\\s+", ignored = true),
+            TokenSpec("lparen", "\\(", ignored = false),
+            TokenSpec("rparen", "\\)", ignored = false),
+            TokenSpec("lbracket", "\\[", ignored = false),
+            TokenSpec("rbracket", "\\]", ignored = false),
+            TokenSpec("lbrace", "\\{", ignored = false),
+            TokenSpec("rbrace", "\\}", ignored = false),
+            TokenSpec("string", "\"[^\"]*\"", ignored = false),
+            TokenSpec("word", "[a-z]+", ignored = false),
+        )
+
+    /** `|` in [textWithCaret] marks the caret; returns the matched (opening, closing) start
+     *  offsets, or null. */
+    private fun match(textWithCaret: String): Pair<Int, Int>? {
+        val caret = textWithCaret.indexOf('|')
+        val text = textWithCaret.replace("|", "")
+        return AlpacaBraceScanner
+            .matchAt(text, "brace-scanner-test", tokens, caret)
+            ?.let { it.first.startOffset to it.second.startOffset }
+    }
+
+    @Test
+    fun `matches an opening paren to its closer with the caret just before it`() {
+        // f(a)  ->  ( at 1, ) at 3
+        assertEquals(1 to 3, match("f|(a)"))
+    }
+
+    @Test
+    fun `matches a closing paren to its opener with the caret just after it`() {
+        assertEquals(1 to 3, match("f(a)|"))
+    }
+
+    @Test
+    fun `respects nesting of the same bracket kind`() {
+        // ((()))  ->  outer ( at 0 pairs with ) at 5
+        assertEquals(0 to 5, match("|((()))"))
+        // caret after the second (  ->  ( at 1 pairs with ) at 4
+        assertEquals(1 to 4, match("(|(())) "))
+    }
+
+    @Test
+    fun `pairs different bracket kinds when they nest properly`() {
+        // {[]}  ->  { at 0 pairs with } at 3
+        assertEquals(0 to 3, match("|{[]}"))
+    }
+
+    @Test
+    fun `ignores brackets inside string tokens`() {
+        // f( "(" )  ->  ( at 1 pairs with ) at 7, not with the ( inside the string
+        assertEquals(1 to 7, match("f|( \"(\" )"))
+    }
+
+    @Test
+    fun `returns null when the caret is not next to a bracket`() {
+        assertNull(match("fo|o (a)"))
+    }
+
+    @Test
+    fun `returns null for an unbalanced bracket`() {
+        assertNull(match("f|(a"))
+    }
+
+    @Test
+    fun `returns null when bracket kinds are interleaved wrong`() {
+        assertNull(match("|( ]"))
+    }
+
+    @Test
+    fun `returns null for a grammar with no bracket tokens`() {
+        val noBrackets = listOf(TokenSpec("word", "[a-z]+", ignored = false))
+        assertNull(AlpacaBraceScanner.matchAt("abc", "no-brackets", noBrackets, 0))
+    }
+}


### PR DESCRIPTION
Roadmap step 3. **Stacked on #557 → #556** — merge those first.

## Why not `PairedBraceMatcher`

`PairedBraceMatcher.getPairs()` takes no context, and Alpaca's token `IElementType`s are per-grammar, so a single static pair list can't describe "the `(` token of *this* file's grammar". `HeavyBraceHighlighter` is the platform's escape hatch for exactly this — it gets the `PsiFile` + caret offset and runs in a background read action.

## Change

- **`AlpacaBraceScanner`** (pure, no PSI/services) — lexes text with the grammar's `AlpacaLexer`, keeps only tokens whose pattern is a single `( ) [ ] { }` (brackets inside string/comment tokens are skipped for free), and pairs them with a bracket-kind stack so `([)]` yields no match.
- **`AlpacaBraceHighlighter`** — the `heavyBracesHighlighter` EP, a thin wrapper: resolve the grammar via `GrammarService`, delegate to the scanner.
- **`bracketRoleOf(pattern)`** in `PatternShape` — `(BracketKind, opening)` for a single-bracket pattern, `null` otherwise.

Multi-line pairs get the gutter line-marker and the scope tooltip from the platform automatically.

## Tests

`AlpacaBraceScannerTest` (plain JUnit): caret before an opener / after a closer, same-kind nesting, cross-kind nesting, brackets inside strings ignored, unbalanced input, wrong interleaving, and a bracket-less grammar all handled.

`./gradlew ktlintCheck test buildPlugin` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)