### PR TITLE
Add test coverage for previously-untested plugin wiring

### DIFF
--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighter.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighter.kt
@@ -22,15 +22,24 @@ class AlpacaBraceHighlighter : HeavyBraceHighlighter() {
         offset: Int,
     ): Boolean = psiFile.language == AlpacaLanguage
 
-    override fun matchBrace(
+    // Widened from the superclass's `protected` so AlpacaBraceHighlighterTest can call it directly
+    // instead of going through the platform's background-highlighting machinery.
+    public override fun matchBrace(
         psiFile: PsiFile,
         offset: Int,
     ): Pair<TextRange, TextRange>? {
         val virtualFile = psiFile.virtualFile ?: psiFile.originalFile.virtualFile ?: return null
         val resolved = GrammarService.getInstance(psiFile.project).resolveForFile(virtualFile) ?: return null
 
+        // Match against the editor document's text, not psiFile.text: the caller highlights the
+        // returned ranges against the document, and while an edit is uncommitted the PSI can still
+        // hold the pre-edit (longer) text, which would put our offsets past the document's end.
+        val text = psiFile.viewProvider.document?.immutableCharSequence ?: return null
+        if (offset > text.length) return null
+
         val (open, close) =
-            AlpacaBraceScanner.matchAt(psiFile.text, resolved.lexerId, resolved.tokens, offset) ?: return null
+            AlpacaBraceScanner.matchAt(text, resolved.lexerId, resolved.tokens, offset) ?: return null
+        if (open.endOffset > text.length || close.endOffset > text.length) return null
         return Pair.create(open, close)
     }
 }

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighter.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighter.kt
@@ -1,0 +1,36 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.grammar.GrammarService
+import com.halotukozak.alpaca.plugin.lexer.AlpacaLanguage
+import com.intellij.codeInsight.highlighting.HeavyBraceHighlighter
+import com.intellij.openapi.util.Pair
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+
+/**
+ * Brace matching for Alpaca-defined languages. Which tokens are brackets, and which open/close,
+ * depends on the file's grammar — not known to a plain [com.intellij.lang.PairedBraceMatcher],
+ * whose `getPairs()` takes no context. [HeavyBraceHighlighter] instead gets the file and caret
+ * offset, so the grammar can be resolved and [AlpacaBraceScanner] run against it.
+ *
+ * The scan lexes the whole file; it runs in a background read action, and the languages Alpaca
+ * targets are small, so that is fine.
+ */
+class AlpacaBraceHighlighter : HeavyBraceHighlighter() {
+    override fun isAvailable(
+        psiFile: PsiFile,
+        offset: Int,
+    ): Boolean = psiFile.language == AlpacaLanguage
+
+    override fun matchBrace(
+        psiFile: PsiFile,
+        offset: Int,
+    ): Pair<TextRange, TextRange>? {
+        val virtualFile = psiFile.virtualFile ?: psiFile.originalFile.virtualFile ?: return null
+        val resolved = GrammarService.getInstance(psiFile.project).resolveForFile(virtualFile) ?: return null
+
+        val (open, close) =
+            AlpacaBraceScanner.matchAt(psiFile.text, resolved.lexerId, resolved.tokens, offset) ?: return null
+        return Pair.create(open, close)
+    }
+}

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceScanner.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceScanner.kt
@@ -1,0 +1,114 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.grammar.BracketKind
+import com.halotukozak.alpaca.plugin.grammar.BracketRole
+import com.halotukozak.alpaca.plugin.grammar.TokenSpec
+import com.halotukozak.alpaca.plugin.grammar.bracketRoleOf
+import com.halotukozak.alpaca.plugin.lexer.ALPACA_BAD_CHARACTER
+import com.halotukozak.alpaca.plugin.lexer.AlpacaLexer
+import com.halotukozak.alpaca.plugin.lexer.AlpacaTokenTypes
+import com.intellij.openapi.util.TextRange
+
+/**
+ * Grammar-agnostic brace matching: lexes text with a grammar's own [AlpacaLexer], keeps the tokens
+ * whose pattern is a single `(` `)` `[` `]` `{` `}` (so brackets inside string/comment tokens are
+ * ignored), and pairs them by nesting. Pure — no PSI or platform services — so it is unit-testable
+ * and [AlpacaBraceHighlighter] is a thin wrapper over it.
+ */
+object AlpacaBraceScanner {
+    private class Bracket(
+        val range: TextRange,
+        val role: BracketRole,
+    )
+
+    /**
+     * The opening/closing brace pair (opening first) touching [caretOffset] — the bracket that
+     * starts at the caret, or failing that the one that ends at it — or null if there is no bracket
+     * there or it has no well-nested match.
+     */
+    fun matchAt(
+        text: CharSequence,
+        lexerId: String,
+        tokenSpecs: List<TokenSpec>,
+        caretOffset: Int,
+    ): Pair<TextRange, TextRange>? {
+        val brackets = collectBrackets(text, lexerId, tokenSpecs)
+        if (brackets.isEmpty()) return null
+
+        val targetIndex =
+            brackets
+                .indexOfFirst { it.range.startOffset == caretOffset }
+                .takeIf { it >= 0 }
+                ?: brackets.indexOfFirst { it.range.endOffset == caretOffset }.takeIf { it >= 0 }
+                ?: return null
+
+        val target = brackets[targetIndex]
+        val matchIndex = if (target.role.opening) matchForward(brackets, targetIndex) else matchBackward(brackets, targetIndex)
+        val match = matchIndex?.let(brackets::get) ?: return null
+
+        return if (target.role.opening) target.range to match.range else match.range to target.range
+    }
+
+    private fun collectBrackets(
+        text: CharSequence,
+        lexerId: String,
+        tokenSpecs: List<TokenSpec>,
+    ): List<Bracket> {
+        val roleByType =
+            tokenSpecs
+                .mapNotNull { spec -> bracketRoleOf(spec.pattern)?.let { AlpacaTokenTypes.forName(lexerId, spec.name) to it } }
+                .toMap()
+        if (roleByType.isEmpty()) return emptyList()
+
+        val lexer = AlpacaLexer(lexerId, tokenSpecs)
+        lexer.start(text, 0, text.length, 0)
+
+        val brackets = mutableListOf<Bracket>()
+        while (true) {
+            val type = lexer.tokenType ?: break
+            if (type != ALPACA_BAD_CHARACTER) {
+                roleByType[type]?.let { role -> brackets += Bracket(TextRange(lexer.tokenStart, lexer.tokenEnd), role) }
+            }
+            lexer.advance()
+        }
+        return brackets
+    }
+
+    /** Index of the closer that balances the opener at [openerIndex], or null if the run isn't well nested. */
+    private fun matchForward(
+        brackets: List<Bracket>,
+        openerIndex: Int,
+    ): Int? {
+        val stack = ArrayDeque<BracketKind>()
+        stack.addLast(brackets[openerIndex].role.kind)
+        for (i in openerIndex + 1 until brackets.size) {
+            val role = brackets[i].role
+            if (role.opening) {
+                stack.addLast(role.kind)
+            } else {
+                if (stack.removeLastOrNull() != role.kind) return null
+                if (stack.isEmpty()) return i
+            }
+        }
+        return null
+    }
+
+    /** Mirror of [matchForward] for a closer at [closerIndex]. */
+    private fun matchBackward(
+        brackets: List<Bracket>,
+        closerIndex: Int,
+    ): Int? {
+        val stack = ArrayDeque<BracketKind>()
+        stack.addLast(brackets[closerIndex].role.kind)
+        for (i in closerIndex - 1 downTo 0) {
+            val role = brackets[i].role
+            if (!role.opening) {
+                stack.addLast(role.kind)
+            } else {
+                if (stack.removeLastOrNull() != role.kind) return null
+                if (stack.isEmpty()) return i
+            }
+        }
+        return null
+    }
+}

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/PatternShape.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/PatternShape.kt
@@ -28,6 +28,28 @@ fun literalTextOf(pattern: String): String? {
     return text.toString()
 }
 
+/** One of the three bracket shapes a single-character token can denote. */
+enum class BracketKind { PARENTHESIS, BRACKET, BRACE }
+
+/** A bracket token's [kind] and whether it is the opening (`(` `[` `{`) or closing (`)` `]` `}`) side. */
+data class BracketRole(
+    val kind: BracketKind,
+    val opening: Boolean,
+)
+
+/** The [BracketRole] [pattern] denotes if it matches exactly one of `( ) [ ] { }` (bare or
+ *  escaped), or null for anything else. */
+fun bracketRoleOf(pattern: String): BracketRole? =
+    when (literalTextOf(pattern)?.singleOrNull()) {
+        '(' -> BracketRole(BracketKind.PARENTHESIS, opening = true)
+        ')' -> BracketRole(BracketKind.PARENTHESIS, opening = false)
+        '[' -> BracketRole(BracketKind.BRACKET, opening = true)
+        ']' -> BracketRole(BracketKind.BRACKET, opening = false)
+        '{' -> BracketRole(BracketKind.BRACE, opening = true)
+        '}' -> BracketRole(BracketKind.BRACE, opening = false)
+        else -> null
+    }
+
 /**
  * The fixed prefix [pattern] denotes for "prefix, then anything to end of line" (`#.*`, `//.*`,
  * ...), the shape Alpaca grammars typically use for line comments among their `ignored` rules.

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/lexer/AlpacaColorSettingsPage.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/lexer/AlpacaColorSettingsPage.kt
@@ -1,0 +1,93 @@
+package com.halotukozak.alpaca.plugin.lexer
+
+import com.halotukozak.alpaca.plugin.grammar.TokenSpec
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.fileTypes.SyntaxHighlighter
+import com.intellij.openapi.options.colors.AttributesDescriptor
+import com.intellij.openapi.options.colors.ColorDescriptor
+import com.intellij.openapi.options.colors.ColorSettingsPage
+import javax.swing.Icon
+
+/**
+ * The **Settings | Editor | Color Scheme | Alpaca** page.
+ *
+ * Alpaca's grammar export carries no per-token semantic category, so [AlpacaSyntaxHighlighter]
+ * infers a fixed handful from each rule's regex shape. This page names those inferred categories
+ * and lets them be recoloured; without it the [TextAttributesKey]s the highlighter uses never
+ * appear in the IDE's colour settings at all.
+ *
+ * The preview is lexed by a real [AlpacaSyntaxHighlighter] over [DEMO_TOKENS], a small built-in
+ * grammar picked so that every category in [DESCRIPTORS] shows up in [DEMO_TEXT].
+ */
+class AlpacaColorSettingsPage : ColorSettingsPage {
+    override fun getDisplayName(): String = "Alpaca"
+
+    override fun getIcon(): Icon? = null
+
+    override fun getAttributeDescriptors(): Array<AttributesDescriptor> = DESCRIPTORS
+
+    override fun getColorDescriptors(): Array<ColorDescriptor> = ColorDescriptor.EMPTY_ARRAY
+
+    override fun getHighlighter(): SyntaxHighlighter = AlpacaSyntaxHighlighter(DEMO_GRAMMAR_ID, DEMO_TOKENS)
+
+    override fun getDemoText(): String = DEMO_TEXT
+
+    override fun getAdditionalHighlightingTagToDescriptorMap(): Map<String, TextAttributesKey>? = null
+
+    companion object {
+        /** Distinct from any real grammar id so [AlpacaTokenTypes] doesn't share token instances with one. */
+        const val DEMO_GRAMMAR_ID: String = "__alpaca_color_settings_demo__"
+
+        private val DESCRIPTORS =
+            arrayOf(
+                AttributesDescriptor("Keyword", AlpacaSyntaxHighlighter.KEYWORD),
+                AttributesDescriptor("Number", AlpacaSyntaxHighlighter.NUMBER),
+                AttributesDescriptor("String", AlpacaSyntaxHighlighter.STRING),
+                AttributesDescriptor("Operator", AlpacaSyntaxHighlighter.OPERATION_SIGN),
+                AttributesDescriptor("Parentheses", AlpacaSyntaxHighlighter.PARENTHESES),
+                AttributesDescriptor("Brackets", AlpacaSyntaxHighlighter.BRACKETS),
+                AttributesDescriptor("Braces", AlpacaSyntaxHighlighter.BRACES),
+                AttributesDescriptor("Dot", AlpacaSyntaxHighlighter.DOT),
+                AttributesDescriptor("Comma", AlpacaSyntaxHighlighter.COMMA),
+                AttributesDescriptor("Semicolon", AlpacaSyntaxHighlighter.SEMICOLON),
+                AttributesDescriptor("Ignored (comments, whitespace)", AlpacaSyntaxHighlighter.IGNORED),
+                AttributesDescriptor("Bad character", AlpacaSyntaxHighlighter.BAD_CHARACTER),
+            )
+
+        /** Every rule here is shaped so [AlpacaSyntaxHighlighter] classifies it into exactly one
+         *  [DESCRIPTORS] category; keyword rules precede the identifier rule so a bare word lexes as
+         *  a keyword on a length tie. */
+        val DEMO_TOKENS: List<TokenSpec> =
+            listOf(
+                TokenSpec("whitespace", "\\s+", ignored = true),
+                TokenSpec("comment", "#.*", ignored = true),
+                TokenSpec("kw_sin", "sin", ignored = false),
+                TokenSpec("kw_let", "let", ignored = false),
+                TokenSpec("identifier", "[a-z]+", ignored = false),
+                TokenSpec("number", "[0-9]+", ignored = false),
+                TokenSpec("string", "\"[^\"]*\"", ignored = false),
+                TokenSpec("op_plus", "\\+", ignored = false),
+                TokenSpec("op_minus", "-", ignored = false),
+                TokenSpec("op_star", "\\*", ignored = false),
+                TokenSpec("op_eq", "=", ignored = false),
+                TokenSpec("lparen", "\\(", ignored = false),
+                TokenSpec("rparen", "\\)", ignored = false),
+                TokenSpec("lbracket", "\\[", ignored = false),
+                TokenSpec("rbracket", "\\]", ignored = false),
+                TokenSpec("lbrace", "\\{", ignored = false),
+                TokenSpec("rbrace", "\\}", ignored = false),
+                TokenSpec("dot", "\\.", ignored = false),
+                TokenSpec("comma", ",", ignored = false),
+                TokenSpec("semicolon", ";", ignored = false),
+            )
+
+        private val DEMO_TEXT =
+            """
+            # Alpaca colours the tokens whose regex shape is unambiguous.
+            let result = sin ( 2 + 3 ) * 42 - 1 ;
+            greeting = "hello, world" ;
+            config { items [ 0 ] . field , next }
+            @ is matched by no rule
+            """.trimIndent()
+    }
+}

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -41,6 +41,7 @@
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.lexer.AlpacaSyntaxHighlighterFactory"/>
     <colorSettingsPage implementation="com.halotukozak.alpaca.plugin.lexer.AlpacaColorSettingsPage"/>
+    <heavyBracesHighlighter implementation="com.halotukozak.alpaca.plugin.editing.AlpacaBraceHighlighter"/>
     <lang.parserDefinition
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.parser.AlpacaParserDefinition"/>

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,7 @@
     <lang.syntaxHighlighterFactory
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.lexer.AlpacaSyntaxHighlighterFactory"/>
+    <colorSettingsPage implementation="com.halotukozak.alpaca.plugin.lexer.AlpacaColorSettingsPage"/>
     <lang.parserDefinition
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.parser.AlpacaParserDefinition"/>

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighterTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceHighlighterTest.kt
@@ -1,0 +1,58 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.lexer.AlpacaFileTypeRegistrar
+import com.halotukozak.alpaca.plugin.settings.AlpacaSettingsState
+import com.halotukozak.alpaca.plugin.settings.GrammarAssociation
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+private const val LEXER_ID = "MathTest.CalcLexer@L11"
+private const val PARSER_ID = "MathTest.MathParser@L39"
+
+/**
+ * Regression coverage for [AlpacaBraceHighlighter.matchBrace]: it must match against the editor
+ * document, not `psiFile.text`, or it can hand the platform a [TextRange] past the document's
+ * current end -- exactly the crash `BackgroundHighlighter` hit mid-edit ("Invalid offsets:
+ * start=210; end=211; document length=210"), because `psiFile.text` can still reflect a longer,
+ * pre-edit version of the file while the corresponding PSI commit hasn't run yet.
+ */
+class AlpacaBraceHighlighterTest : BasePlatformTestCase() {
+    private val highlighter = AlpacaBraceHighlighter()
+
+    override fun setUp() {
+        super.setUp()
+        val settings = AlpacaSettingsState.getInstance(project)
+        settings.exportDirectory = "/tmp/alpaca-grammar-export"
+        settings.associations =
+            mutableListOf(GrammarAssociation(extension = "calc", lexerGrammarId = LEXER_ID, parserGrammarId = PARSER_ID))
+        runWriteAction { AlpacaFileTypeRegistrar.ensureRegistered("calc", LEXER_ID) }
+    }
+
+    fun `test matches a paren pair once the document is committed`() {
+        val file = myFixture.configureByText("test.calc", "(1+2)")
+
+        val match = highlighter.matchBrace(file, 0)
+
+        assertEquals(TextRange(0, 1), match?.first)
+        assertEquals(TextRange(4, 5), match?.second)
+    }
+
+    fun `test never matches past the document end while an edit is uncommitted`() {
+        val file = myFixture.configureByText("test.calc", "(1+2)")
+        val document = myFixture.editor.document
+
+        // Shrink the document directly, without committing PSI: psiFile.text (and the PSI tree)
+        // still reflects the old, longer text -- the same staleness BackgroundHighlighter can see
+        // mid-keystroke, before the commit that normally follows a real edit.
+        WriteCommandAction.runWriteCommandAction(project) { document.deleteString(4, 5) }
+        assertFalse(PsiDocumentManager.getInstance(project).isCommitted(document))
+
+        val match = highlighter.matchBrace(file, document.textLength)
+
+        assertTrue((match?.first?.endOffset ?: 0) <= document.textLength)
+        assertTrue((match?.second?.endOffset ?: 0) <= document.textLength)
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceScannerTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBraceScannerTest.kt
@@ -1,0 +1,83 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.grammar.TokenSpec
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AlpacaBraceScannerTest {
+    private val tokens =
+        listOf(
+            TokenSpec("ws", "\\s+", ignored = true),
+            TokenSpec("lparen", "\\(", ignored = false),
+            TokenSpec("rparen", "\\)", ignored = false),
+            TokenSpec("lbracket", "\\[", ignored = false),
+            TokenSpec("rbracket", "\\]", ignored = false),
+            TokenSpec("lbrace", "\\{", ignored = false),
+            TokenSpec("rbrace", "\\}", ignored = false),
+            TokenSpec("string", "\"[^\"]*\"", ignored = false),
+            TokenSpec("word", "[a-z]+", ignored = false),
+        )
+
+    /** `|` in [textWithCaret] marks the caret; returns the matched (opening, closing) start
+     *  offsets, or null. */
+    private fun match(textWithCaret: String): Pair<Int, Int>? {
+        val caret = textWithCaret.indexOf('|')
+        val text = textWithCaret.replace("|", "")
+        return AlpacaBraceScanner
+            .matchAt(text, "brace-scanner-test", tokens, caret)
+            ?.let { it.first.startOffset to it.second.startOffset }
+    }
+
+    @Test
+    fun `matches an opening paren to its closer with the caret just before it`() {
+        // f(a)  ->  ( at 1, ) at 3
+        assertEquals(1 to 3, match("f|(a)"))
+    }
+
+    @Test
+    fun `matches a closing paren to its opener with the caret just after it`() {
+        assertEquals(1 to 3, match("f(a)|"))
+    }
+
+    @Test
+    fun `respects nesting of the same bracket kind`() {
+        // ((()))  ->  outer ( at 0 pairs with ) at 5
+        assertEquals(0 to 5, match("|((()))"))
+        // caret after the second (  ->  ( at 1 pairs with ) at 4
+        assertEquals(1 to 4, match("(|(())) "))
+    }
+
+    @Test
+    fun `pairs different bracket kinds when they nest properly`() {
+        // {[]}  ->  { at 0 pairs with } at 3
+        assertEquals(0 to 3, match("|{[]}"))
+    }
+
+    @Test
+    fun `ignores brackets inside string tokens`() {
+        // f( "(" )  ->  ( at 1 pairs with ) at 7, not with the ( inside the string
+        assertEquals(1 to 7, match("f|( \"(\" )"))
+    }
+
+    @Test
+    fun `returns null when the caret is not next to a bracket`() {
+        assertNull(match("fo|o (a)"))
+    }
+
+    @Test
+    fun `returns null for an unbalanced bracket`() {
+        assertNull(match("f|(a"))
+    }
+
+    @Test
+    fun `returns null when bracket kinds are interleaved wrong`() {
+        assertNull(match("|( ]"))
+    }
+
+    @Test
+    fun `returns null for a grammar with no bracket tokens`() {
+        val noBrackets = listOf(TokenSpec("word", "[a-z]+", ignored = false))
+        assertNull(AlpacaBraceScanner.matchAt("abc", "no-brackets", noBrackets, 0))
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/grammar/GrammarExportChangeListenerTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/grammar/GrammarExportChangeListenerTest.kt
@@ -1,0 +1,76 @@
+package com.halotukozak.alpaca.plugin.grammar
+
+import com.halotukozak.alpaca.plugin.settings.AlpacaSettingsState
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.nio.file.Files
+import java.nio.file.Path
+
+class GrammarExportChangeListenerTest : BasePlatformTestCase() {
+    private lateinit var exportDir: Path
+
+    override fun setUp() {
+        super.setUp()
+        exportDir = Files.createTempDirectory("grammar-export-listener-test")
+        AlpacaSettingsState.getInstance(project).exportDirectory = exportDir.toString()
+    }
+
+    override fun tearDown() {
+        try {
+            AlpacaSettingsState.getInstance(project).exportDirectory = ""
+            Files.walk(exportDir).sorted(Comparator.reverseOrder()).forEach(Files::delete)
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    private fun writeLexer(
+        id: String,
+        tokensJson: String,
+    ) = Files.writeString(exportDir.resolve("$id.tokens.json"), tokensJson)
+
+    private fun GrammarService.singleLexerTokenNames(): List<String> =
+        exportedGrammars()
+            .lexers
+            .single()
+            .tokens
+            .map { it.name }
+
+    private fun contentChangeEventAt(path: Path): VFileEvent {
+        val virtualFile =
+            LocalFileSystem.getInstance().refreshAndFindFileByNioFile(path)
+                ?: error("expected $path to exist on disk")
+        val requestor = this
+        return VFileContentChangeEvent(requestor, virtualFile, 0, 1)
+    }
+
+    fun `test invalidates the cache when a changed file is under the export directory`() {
+        writeLexer("L@L1", """[{"name":"A","pattern":"a","ignored":false}]""")
+        val service = GrammarService.getInstance(project)
+        assertEquals(listOf("A"), service.singleLexerTokenNames())
+
+        // Change the file on disk behind the cache, exactly like GrammarServiceTest does, then
+        // let the listener notice.
+        writeLexer("L@L1", """[{"name":"B","pattern":"b","ignored":false}]""")
+        GrammarExportChangeListener(project).after(listOf(contentChangeEventAt(exportDir.resolve("L@L1.tokens.json"))))
+
+        assertEquals(listOf("B"), service.singleLexerTokenNames())
+    }
+
+    fun `test leaves the cache untouched when no event is under the export directory`() {
+        writeLexer("L@L1", """[{"name":"A","pattern":"a","ignored":false}]""")
+        val service = GrammarService.getInstance(project)
+        assertEquals(listOf("A"), service.singleLexerTokenNames())
+
+        writeLexer("L@L1", """[{"name":"B","pattern":"b","ignored":false}]""")
+        val elsewhere = Files.createTempFile("grammar-export-listener-test-unrelated", ".json")
+        try {
+            GrammarExportChangeListener(project).after(listOf(contentChangeEventAt(elsewhere)))
+            assertEquals(listOf("A"), service.singleLexerTokenNames())
+        } finally {
+            Files.deleteIfExists(elsewhere)
+        }
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/lexer/AlpacaColorSettingsPageTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/lexer/AlpacaColorSettingsPageTest.kt
@@ -1,0 +1,38 @@
+package com.halotukozak.alpaca.plugin.lexer
+
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AlpacaColorSettingsPageTest {
+    private val page = AlpacaColorSettingsPage()
+
+    @Test
+    fun `every attribute descriptor is exercised by the demo text`() {
+        val highlighter = page.highlighter
+        val lexer = highlighter.highlightingLexer
+        val demoText = page.demoText
+        lexer.start(demoText, 0, demoText.length, 0)
+
+        val keysHit = mutableSetOf<TextAttributesKey>()
+        while (lexer.tokenType != null) {
+            highlighter.getTokenHighlights(lexer.tokenType).forEach(keysHit::add)
+            lexer.advance()
+        }
+
+        val descriptorKeys = page.attributeDescriptors.map { it.key }.toSet()
+        assertEquals(
+            "demo text does not exercise: ${descriptorKeys - keysHit}",
+            descriptorKeys,
+            keysHit,
+        )
+    }
+
+    @Test
+    fun `descriptor names are unique and non-blank`() {
+        val names = page.attributeDescriptors.map { it.displayName }
+        assertTrue(names.none { it.isBlank() })
+        assertEquals(names.size, names.toSet().size)
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/lexer/AlpacaFileTypeRegistrarTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/lexer/AlpacaFileTypeRegistrarTest.kt
@@ -1,0 +1,29 @@
+package com.halotukozak.alpaca.plugin.lexer
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class AlpacaFileTypeRegistrarTest : BasePlatformTestCase() {
+    fun `test associates the extension with an AlpacaFileType for the given grammar`() {
+        runWriteAction { AlpacaFileTypeRegistrar.ensureRegistered("registrar-test-ext", "SomeGrammar@L1") }
+
+        val fileType = FileTypeManager.getInstance().getFileTypeByExtension("registrar-test-ext")
+
+        assertInstanceOf(fileType, AlpacaFileType::class.java)
+        assertEquals("Alpaca:SomeGrammar@L1", fileType.name)
+    }
+
+    fun `test reuses the same file type instance for the same grammar id`() {
+        runWriteAction {
+            AlpacaFileTypeRegistrar.ensureRegistered("registrar-test-a", "SharedGrammar@L2")
+            AlpacaFileTypeRegistrar.ensureRegistered("registrar-test-b", "SharedGrammar@L2")
+        }
+
+        val fileTypeManager = FileTypeManager.getInstance()
+        assertSame(
+            fileTypeManager.getFileTypeByExtension("registrar-test-a"),
+            fileTypeManager.getFileTypeByExtension("registrar-test-b"),
+        )
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/lexer/AlpacaSyntaxHighlighterFactoryTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/lexer/AlpacaSyntaxHighlighterFactoryTest.kt
@@ -1,0 +1,60 @@
+package com.halotukozak.alpaca.plugin.lexer
+
+import com.halotukozak.alpaca.plugin.settings.AlpacaSettingsState
+import com.halotukozak.alpaca.plugin.settings.GrammarAssociation
+import com.intellij.lexer.Lexer
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+private const val LEXER_ID = "MathTest.CalcLexer@L11"
+
+/**
+ * [AlpacaSyntaxHighlighterFactory] is the entry point the platform actually calls per file, so
+ * these tests exercise the grammar-resolution + fallback wiring end to end, on top of the plain
+ * lexing already covered by [AlpacaLexerTest] and [AlpacaSyntaxHighlighterTest].
+ */
+class AlpacaSyntaxHighlighterFactoryTest : BasePlatformTestCase() {
+    private val factory = AlpacaSyntaxHighlighterFactory()
+
+    override fun setUp() {
+        super.setUp()
+        val settings = AlpacaSettingsState.getInstance(project)
+        settings.exportDirectory = "/tmp/alpaca-grammar-export"
+        settings.associations = mutableListOf(GrammarAssociation(extension = "calc", lexerGrammarId = LEXER_ID))
+    }
+
+    private fun tokenTypesOf(
+        text: String,
+        lexer: Lexer,
+    ): List<String> {
+        lexer.start(text, 0, text.length, 0)
+        val types = mutableListOf<String>()
+        while (lexer.tokenType != null) {
+            types += lexer.tokenType.toString()
+            lexer.advance()
+        }
+        return types
+    }
+
+    fun `test resolves the mapped grammar for a file with an associated extension`() {
+        val file = myFixture.configureByText("test.calc", "1 + 2").virtualFile
+        val highlighter = factory.getSyntaxHighlighter(project, file)
+
+        assertEquals(
+            listOf("int", "[ \t\r\n]+", "\\+", "[ \t\r\n]+", "int"),
+            tokenTypesOf("1 + 2", highlighter.highlightingLexer),
+        )
+    }
+
+    fun `test falls back to an unresolved empty grammar for a file with no association`() {
+        val file = myFixture.configureByText("test.txt", "x").virtualFile
+        val highlighter = factory.getSyntaxHighlighter(project, file)
+
+        assertEquals(listOf("ALPACA_BAD_CHARACTER"), tokenTypesOf("x", highlighter.highlightingLexer))
+    }
+
+    fun `test falls back to an unresolved empty grammar when project or file is null`() {
+        val highlighter = factory.getSyntaxHighlighter(null, null)
+
+        assertEquals(listOf("ALPACA_BAD_CHARACTER"), tokenTypesOf("x", highlighter.highlightingLexer))
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/settings/AlpacaSettingsConfigurableTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/settings/AlpacaSettingsConfigurableTest.kt
@@ -1,0 +1,82 @@
+package com.halotukozak.alpaca.plugin.settings
+
+import com.halotukozak.alpaca.plugin.grammar.GrammarService
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.nio.file.Files
+import java.nio.file.Path
+
+class AlpacaSettingsConfigurableTest : BasePlatformTestCase() {
+    private lateinit var exportDir: Path
+    private lateinit var settings: AlpacaSettingsState
+
+    override fun setUp() {
+        super.setUp()
+        exportDir = Files.createTempDirectory("settings-configurable-test")
+        settings = AlpacaSettingsState.getInstance(project)
+        settings.exportDirectory = exportDir.toString()
+        settings.associations = mutableListOf()
+    }
+
+    override fun tearDown() {
+        try {
+            settings.exportDirectory = ""
+            settings.associations = mutableListOf()
+            Files.walk(exportDir).sorted(Comparator.reverseOrder()).forEach(Files::delete)
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun `test apply registers a file type for each association and refreshes the grammar cache`() {
+        // Warm the cache while the export directory is still empty, exactly like a real session
+        // that opened the project before the grammar was exported.
+        assertEmpty(GrammarService.getInstance(project).exportedGrammars().lexers)
+
+        Files.writeString(
+            exportDir.resolve("CfgTest.L@L1.tokens.json"),
+            """[{"name":"kw","pattern":"let","ignored":false}]""",
+        )
+        settings.associations = mutableListOf(GrammarAssociation(extension = "cfgtest-ext", lexerGrammarId = "CfgTest.L@L1"))
+
+        val configurable = AlpacaSettingsConfigurable(project)
+        configurable.reset()
+        configurable.apply()
+
+        val fileType = FileTypeManager.getInstance().getFileTypeByExtension("cfgtest-ext")
+        assertEquals("Alpaca:CfgTest.L@L1", fileType.name)
+
+        // Only passes if apply() actually dropped the cache warmed above, not just re-read settings.
+        val lexerIds =
+            GrammarService
+                .getInstance(project)
+                .exportedGrammars()
+                .lexers
+                .map { it.id }
+        assertEquals(listOf("CfgTest.L@L1"), lexerIds)
+    }
+
+    fun `test isModified compares the loaded fields against the current settings, not their initial values`() {
+        settings.associations = mutableListOf(GrammarAssociation(extension = "a", lexerGrammarId = "A@L1"))
+        val configurable = AlpacaSettingsConfigurable(project)
+        configurable.reset()
+
+        assertFalse(configurable.isModified())
+
+        // Settings changed elsewhere (e.g. GrammarExportChangeListener) while the dialog was open.
+        settings.associations = mutableListOf(GrammarAssociation(extension = "b", lexerGrammarId = "B@L1"))
+
+        assertTrue(configurable.isModified())
+    }
+
+    fun `test isModified reacts to the export directory as well as the mappings`() {
+        val configurable = AlpacaSettingsConfigurable(project)
+        configurable.reset()
+
+        assertFalse(configurable.isModified())
+
+        settings.exportDirectory = "$exportDir/elsewhere"
+
+        assertTrue(configurable.isModified())
+    }
+}


### PR DESCRIPTION
Part of the ij-plugin roadmap follow-up: fills in test coverage gaps found while
verifying the plugin end-to-end in a sandbox IDE this session.

- `GrammarExportChangeListenerTest` — cache invalidation only for events under the
  export directory.
- `AlpacaFileTypeRegistrarTest` — extension association + per-grammar file type caching.
- `AlpacaSyntaxHighlighterFactoryTest` — grammar resolution and the unresolved-grammar
  fallback.
- `AlpacaSettingsConfigurableTest` — `apply()`'s file-type registration + cache
  invalidation, and `isModified()` against live settings changes.

`AlpacaGrammarStartupActivity` is deliberately left without a dedicated unit test: driving
its suspending `writeAction {}` end-to-end from a JUnit thread deadlocked for real (25+
minutes, twice, even through the platform's own `timeoutRunBlocking` test helper) — the
same EDT/coroutine-dispatch hazard behind the real "Debug metadata version mismatch" crash
this session hit running the sandbox IDE. Its own logic is a thin composition of
`ensureRegistered`/`syncWatchedRoots`/`exportedGrammars`, already covered individually.

Stacked on #558 (`brace-matching`), which also got a regression test + real bug fix for a
brace-highlighter crash found while trying the plugin live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)