### PR TITLE
Make plugin CI a blocking check without stalling unrelated PRs

### DIFF
--- a/.github/workflows/ij-plugin-test.yml
+++ b/.github/workflows/ij-plugin-test.yml
@@ -2,19 +2,46 @@ name: IntelliJ Plugin
 
 on:
   pull_request:
-    paths:
-      - 'ij-plugin/**'
-      - '.github/workflows/ij-plugin-test.yml'
   push:
     branches: [ main ]
-    paths:
-      - 'ij-plugin/**'
-      - '.github/workflows/ij-plugin-test.yml'
 
 # CI for the Kotlin IntelliJ plugin under ij-plugin/, kept separate from the Mill-built Scala
 # library's own Test workflow since the two projects have nothing in common build-wise.
+#
+# The workflow itself has no path filter: `plugin-ci` is a required status check on `main`, and
+# a required check whose workflow is filtered out never reports, which blocks every unrelated PR
+# forever. Instead the `changes` job decides per-PR whether `test`/`verify` need to run, and
+# `plugin-ci` always runs to report the verdict -- so a docs-only PR spends ~30s here, not ~15m.
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      plugin: ${{ steps.filter.outputs.plugin }}
+    steps:
+      - name: Detect whether this change touches the plugin
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Anything that isn't a PR (a push to main, a manual run) always gets the full build.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "plugin=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+          if grep -qE '^(ij-plugin/|\.github/workflows/ij-plugin-test\.yml$)' <<< "$changed"; then
+            echo "plugin=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "plugin=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
+    needs: changes
+    if: ${{ needs.changes.outputs.plugin == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -67,6 +94,8 @@ jobs:
   # Verifier against the IDEs the platform recommends. Separate job: it downloads full
   # IDE distributions and has nothing to do with the grammar-export test setup above.
   verify:
+    needs: changes
+    if: ${{ needs.changes.outputs.plugin == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -92,3 +121,24 @@ jobs:
         with:
           name: plugin-verifier-report
           path: ij-plugin/build/reports/pluginVerifier
+
+  # The one required status check for the plugin. Always runs, so a PR that skips the jobs
+  # above still reports a result; fails only when a job that did run did not succeed.
+  plugin-ci:
+    name: Plugin CI
+    needs: [ changes, test, verify ]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check plugin job results
+        run: |
+          echo "changes=${{ needs.changes.result }} test=${{ needs.test.result }} verify=${{ needs.verify.result }}"
+          for result in \
+            "${{ needs.changes.result }}" \
+            "${{ needs.test.result }}" \
+            "${{ needs.verify.result }}"; do
+            case "$result" in
+              success | skipped) ;;
+              *) echo "::error::a plugin CI job did not pass (got '$result')"; exit 1 ;;
+            esac
+          done


### PR DESCRIPTION
## Problem

The plugin's `test` and `verify` jobs are **not required status checks** on `main`, so a PR that breaks the IntelliJ plugin can still be merged (as nearly happened when the #558 stack was merged with `verify` still running).

They also can't just be flipped to "required": `ij-plugin-test.yml` was path-filtered to `ij-plugin/**`, and GitHub leaves a required check whose workflow didn't run stuck as *"Expected — waiting for status"*, which would block every docs / dependency-bump PR forever. ~78% of recent PRs (31 of the last 40) don't touch the plugin.

## Change

| job | when it runs | required? |
|---|---|---|
| `changes` | always | no |
| `test` | plugin files changed, or push to `main` | no |
| `verify` | plugin files changed, or push to `main` | no |
| **`Plugin CI`** | **always** | **yes (to be added)** |

- `changes` reads the PR's file list (`gh api …/files`, no extra action) and sets an output.
- `test` / `verify` gate on it — a non-plugin PR skips them, and skips the ~9‑minute Plugin Verifier + its IDE downloads (~30s total here instead of ~15m).
- `Plugin CI` always runs and is the single check to require: green when the jobs passed **or were skipped**, red when a job that actually ran failed.

## Follow-up (repo admin, after merge)

Add `Plugin CI` to `main`'s required status checks:

```
gh api -X PATCH repos/halotukozak-com/alpaca/branches/main/protection/required_status_checks \
  -f 'checks[][context]=Scalafmt' -f 'checks[][context]=Test (jvm)' \
  -f 'checks[][context]=Test (native)' -f 'checks[][context]=Test (js)' \
  -f 'checks[][context]=Docs' -f 'checks[][context]=Plugin CI'
```

Other open PRs will need a rebase to pick up the new workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)