### PR TITLE
Add a generic FormattingModelBuilder (Reformat Code support)

### DIFF
--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaBlock.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaBlock.kt
@@ -1,0 +1,83 @@
+package com.halotukozak.alpaca.plugin.formatting
+
+import com.intellij.formatting.Block
+import com.intellij.formatting.ChildAttributes
+import com.intellij.formatting.Indent
+import com.intellij.formatting.Spacing
+import com.intellij.formatting.SpacingBuilder
+import com.intellij.lang.ASTNode
+import com.intellij.psi.formatter.common.AbstractBlock
+
+/**
+ * One block per non-blank AST node. A pure-whitespace leaf gets no block at all -- its text is
+ * regenerated from [getSpacing] like any other gap -- but a comment leaf, despite also being an
+ * `ignored` rule like whitespace, keeps its own block so reformatting can't eat it.
+ *
+ * Indentation is inferred purely from [roles]: when a node's own children end with a bracket
+ * closer that has a matching opener earlier among the *same* direct children ([bracketSpan]),
+ * whatever sits strictly between that pair is indented one level, exactly like a `{ ... }`/
+ * `( ... )`/`[ ... ]` block in any conventional language -- regardless of which nonterminal
+ * produced it, and regardless of what (if anything) precedes the opener, e.g. a function-call
+ * production `Call -> ID "(" Args ")"` indents `Args` the same as a bare `"(" Expr ")"` would. A
+ * left-recursive list production (`List -> List "," Expr`) is not itself bracket-delimited, so it
+ * adds no indent of its own; only the one bracket pair enclosing the whole list does, so a wrapped
+ * list ends up at exactly one indent level deeper than the bracket, not one level per recursive
+ * list node.
+ */
+class AlpacaBlock(
+    node: ASTNode,
+    private val roles: FormattingRoles,
+    private val spacingBuilder: SpacingBuilder,
+    private val indent: Indent,
+) : AbstractBlock(node, null, null) {
+    override fun getIndent(): Indent = indent
+
+    override fun isLeaf(): Boolean = node.firstChildNode == null
+
+    override fun buildChildren(): List<Block> {
+        val children = nonBlankChildren()
+        val span = bracketSpan(children)
+        return children.mapIndexed { index, child ->
+            val interior = span != null && index > span.open && index < span.close
+            AlpacaBlock(child, roles, spacingBuilder, if (interior) Indent.getNormalIndent() else Indent.getNoneIndent())
+        }
+    }
+
+    override fun getSpacing(
+        child1: Block?,
+        child2: Block,
+    ): Spacing = spacingBuilder.getSpacing(this, child1, child2) ?: DEFAULT_SPACING
+
+    override fun getChildAttributes(newChildIndex: Int): ChildAttributes {
+        val span = bracketSpan(nonBlankChildren())
+        val interior = span != null && newChildIndex > span.open && newChildIndex <= span.close
+        return ChildAttributes(if (interior) Indent.getNormalIndent() else Indent.getNoneIndent(), null)
+    }
+
+    private fun nonBlankChildren(): List<ASTNode> = node.getChildren(null).filter { it.text.isNotBlank() }
+
+    /** The last child's index, if it is a bracket closer with a matching opener earlier in
+     *  [children] -- the opener's own index and the closer's (always [children]'s last index). */
+    private fun bracketSpan(children: List<ASTNode>): BracketSpan? {
+        val close = children.lastIndex
+        if (close < 0) return null
+        val closerRole = roles.roleOf(children[close].elementType)?.takeIf { !it.opening } ?: return null
+        val open =
+            children.indexOfFirst { child ->
+                roles.roleOf(child.elementType)?.let { it.opening && it.kind == closerRole.kind } == true
+            }
+        return if (open in 0 until close) BracketSpan(open, close) else null
+    }
+
+    private data class BracketSpan(
+        val open: Int,
+        val close: Int,
+    )
+
+    companion object {
+        // No special rule matched: one space, no forced line break, but keep one if the user
+        // already put it there (so a multi-line bracket group's line breaks survive reformatting),
+        // and collapse longer runs of blank lines down to at most one.
+        private val DEFAULT_SPACING = Spacing.createSpacing(1, 1, 0, true, 1)
+    }
+}

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaBlock.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaBlock.kt
@@ -13,6 +13,13 @@ import com.intellij.psi.formatter.common.AbstractBlock
  * regenerated from [getSpacing] like any other gap -- but a comment leaf, despite also being an
  * `ignored` rule like whitespace, keeps its own block so reformatting can't eat it.
  *
+ * Spacing only ever touches what [FormattingRoles] classifies (no space just inside a bracket
+ * pair or around `,`/`;`/`.`): anywhere else, [getSpacing] returns null and the formatter leaves
+ * whatever the user actually typed alone. There is deliberately no generic "one space between any
+ * two tokens" fallback -- with no semantics, that would just be a different unjustified opinion
+ * (e.g. it made a keyword-shaped call like `atan2(1, 1)` reformat to `atan2 (1, 1)`, and spaced
+ * out a tight-packed grammar like Brainfuck's `+++` into `+ + +`).
+ *
  * Indentation is inferred purely from [roles]: when a node's own children end with a bracket
  * closer that has a matching opener earlier among the *same* direct children ([bracketSpan]),
  * whatever sits strictly between that pair is indented one level, exactly like a `{ ... }`/
@@ -46,7 +53,7 @@ class AlpacaBlock(
     override fun getSpacing(
         child1: Block?,
         child2: Block,
-    ): Spacing = spacingBuilder.getSpacing(this, child1, child2) ?: DEFAULT_SPACING
+    ): Spacing? = spacingBuilder.getSpacing(this, child1, child2)
 
     override fun getChildAttributes(newChildIndex: Int): ChildAttributes {
         val span = bracketSpan(nonBlankChildren())
@@ -73,11 +80,4 @@ class AlpacaBlock(
         val open: Int,
         val close: Int,
     )
-
-    companion object {
-        // No special rule matched: one space, no forced line break, but keep one if the user
-        // already put it there (so a multi-line bracket group's line breaks survive reformatting),
-        // and collapse longer runs of blank lines down to at most one.
-        private val DEFAULT_SPACING = Spacing.createSpacing(1, 1, 0, true, 1)
-    }
 }

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilder.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilder.kt
@@ -1,0 +1,44 @@
+package com.halotukozak.alpaca.plugin.formatting
+
+import com.halotukozak.alpaca.plugin.grammar.GrammarService
+import com.halotukozak.alpaca.plugin.lexer.AlpacaLanguage
+import com.intellij.formatting.FormattingContext
+import com.intellij.formatting.FormattingModel
+import com.intellij.formatting.FormattingModelBuilder
+import com.intellij.formatting.FormattingModelProvider
+import com.intellij.formatting.Indent
+import com.intellij.formatting.SpacingBuilder
+
+/**
+ * Grammar-agnostic reformatting for Alpaca-defined languages: resolves the file's grammar the
+ * same way [com.halotukozak.alpaca.plugin.editing.AlpacaBraceHighlighter] and
+ * [com.halotukozak.alpaca.plugin.lexer.AlpacaSyntaxHighlighterFactory] do, classifies its tokens
+ * by shape ([FormattingRoles]), and builds an [AlpacaBlock] tree from that -- no per-grammar code,
+ * just opinionated defaults: a single space between most tokens, none just inside a bracket pair
+ * or around `,`/`;`/`.`, and one indent level for whatever a matching bracket pair encloses.
+ */
+class AlpacaFormattingModelBuilder : FormattingModelBuilder {
+    override fun createModel(formattingContext: FormattingContext): FormattingModel {
+        val file = formattingContext.containingFile
+        val settings = formattingContext.codeStyleSettings
+        val virtualFile = file.virtualFile ?: file.originalFile.virtualFile
+        val resolved = virtualFile?.let { GrammarService.getInstance(formattingContext.project).resolveForFile(it) }
+        val roles = FormattingRoles.of(resolved?.lexerId ?: "<unresolved>", resolved?.tokens.orEmpty())
+
+        val spacingBuilder =
+            SpacingBuilder(settings, AlpacaLanguage)
+                .after(roles.openers)
+                .spaceIf(false)
+                .before(roles.closers)
+                .spaceIf(false)
+                .before(roles.commas)
+                .spaceIf(false)
+                .before(roles.semicolons)
+                .spaceIf(false)
+                .around(roles.dots)
+                .spaceIf(false)
+
+        val rootBlock = AlpacaBlock(file.node, roles, spacingBuilder, Indent.getNoneIndent())
+        return FormattingModelProvider.createFormattingModelForPsiFile(file, rootBlock, settings)
+    }
+}

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilder.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilder.kt
@@ -14,8 +14,9 @@ import com.intellij.formatting.SpacingBuilder
  * same way [com.halotukozak.alpaca.plugin.editing.AlpacaBraceHighlighter] and
  * [com.halotukozak.alpaca.plugin.lexer.AlpacaSyntaxHighlighterFactory] do, classifies its tokens
  * by shape ([FormattingRoles]), and builds an [AlpacaBlock] tree from that -- no per-grammar code,
- * just opinionated defaults: a single space between most tokens, none just inside a bracket pair
- * or around `,`/`;`/`.`, and one indent level for whatever a matching bracket pair encloses.
+ * and no opinion on anything [FormattingRoles] doesn't classify: no space just inside a bracket
+ * pair or around `,`/`;`/`.`, one indent level for whatever a matching bracket pair encloses, and
+ * everything else left exactly as the user typed it (see [AlpacaBlock.getSpacing]).
  */
 class AlpacaFormattingModelBuilder : FormattingModelBuilder {
     override fun createModel(formattingContext: FormattingContext): FormattingModel {

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/formatting/FormattingRoles.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/formatting/FormattingRoles.kt
@@ -1,0 +1,59 @@
+package com.halotukozak.alpaca.plugin.formatting
+
+import com.halotukozak.alpaca.plugin.grammar.BracketRole
+import com.halotukozak.alpaca.plugin.grammar.TokenSpec
+import com.halotukozak.alpaca.plugin.grammar.bracketRoleOf
+import com.halotukozak.alpaca.plugin.grammar.literalTextOf
+import com.halotukozak.alpaca.plugin.lexer.AlpacaTokenTypes
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.TokenSet
+
+/**
+ * Classifies one grammar's tokens by shape, the same way
+ * [com.halotukozak.alpaca.plugin.editing.AlpacaBraceScanner] and
+ * [com.halotukozak.alpaca.plugin.lexer.AlpacaSyntaxHighlighter] do: a rule whose pattern is a
+ * fixed `(`/`)`/`[`/`]`/`{`/`}`, `,`, `;`, or `.` gets a role here; anything else (including an
+ * identifier-shaped keyword) is unclassified and only ever gets [AlpacaBlock]'s generic default
+ * spacing and indent.
+ */
+class FormattingRoles private constructor(
+    private val bracketRoles: Map<IElementType, BracketRole>,
+    val openers: TokenSet,
+    val closers: TokenSet,
+    val commas: TokenSet,
+    val semicolons: TokenSet,
+    val dots: TokenSet,
+) {
+    fun roleOf(type: IElementType): BracketRole? = bracketRoles[type]
+
+    companion object {
+        fun of(
+            grammarId: String,
+            tokens: List<TokenSpec>,
+        ): FormattingRoles {
+            val bracketRoles = HashMap<IElementType, BracketRole>()
+            val commas = mutableListOf<IElementType>()
+            val semicolons = mutableListOf<IElementType>()
+            val dots = mutableListOf<IElementType>()
+            for (spec in tokens) {
+                val type = AlpacaTokenTypes.forName(grammarId, spec.name)
+                bracketRoleOf(spec.pattern)?.let { bracketRoles[type] = it }
+                when (literalTextOf(spec.pattern)) {
+                    "," -> commas += type
+                    ";" -> semicolons += type
+                    "." -> dots += type
+                }
+            }
+            val openers = bracketRoles.filterValues { it.opening }.keys
+            val closers = bracketRoles.filterValues { !it.opening }.keys
+            return FormattingRoles(
+                bracketRoles = bracketRoles,
+                openers = TokenSet.create(*openers.toTypedArray()),
+                closers = TokenSet.create(*closers.toTypedArray()),
+                commas = TokenSet.create(*commas.toTypedArray()),
+                semicolons = TokenSet.create(*semicolons.toTypedArray()),
+                dots = TokenSet.create(*dots.toTypedArray()),
+            )
+        }
+    }
+}

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,8 @@
       <li><b>Structure View</b> and <b>code folding</b> that mirror the parsed tree.</li>
       <li><b>Autocompletion</b> of the fixed-spelling terminals valid at the caret.</li>
       <li><b>Line comment toggling</b> for grammars with a <code>prefix.*</code>-shaped ignored rule.</li>
+      <li><b>Reformat Code</b> that spaces and indents around your grammar's brackets, commas, semicolons,
+        and dots, however they're spelled.</li>
     </ul>
     <p>
       Point <b>Settings | Tools | Alpaca</b> at your grammar export directory and map file extensions
@@ -57,6 +59,9 @@
     <lang.commenter
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.commenter.AlpacaCommenter"/>
+    <lang.formatter
+        language="Alpaca"
+        implementationClass="com.halotukozak.alpaca.plugin.formatting.AlpacaFormattingModelBuilder"/>
   </extensions>
 
   <projectListeners>

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilderBrainfuckTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilderBrainfuckTest.kt
@@ -41,11 +41,9 @@ class AlpacaFormattingModelBuilderBrainfuckTest : BasePlatformTestCase() {
         assertEquals("[\n    +\n]", result)
     }
 
-    fun `test spaces consecutive operations that have no special role`() {
-        // Brainfuck's own convention packs operations tight with no separators at all, but none
-        // of `+`/`-`/`>`/`<` is a bracket/comma/semicolon/dot, so they get the same generic
-        // default spacing as any other unclassified token pair -- a known tradeoff of having no
-        // per-grammar rules, not a bug specific to this grammar.
-        assertEquals("+ + +", reformat("+++"))
+    fun `test leaves consecutive operations exactly as typed`() {
+        // None of `+`/`-`/`>`/`<` is a bracket/comma/semicolon/dot, and there is no generic
+        // fallback spacing rule, so Brainfuck's own tight-packed convention survives untouched.
+        assertEquals("+++", reformat("+++"))
     }
 }

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilderBrainfuckTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilderBrainfuckTest.kt
@@ -1,0 +1,51 @@
+package com.halotukozak.alpaca.plugin.formatting
+
+import com.halotukozak.alpaca.plugin.lexer.AlpacaFileTypeRegistrar
+import com.halotukozak.alpaca.plugin.settings.AlpacaSettingsState
+import com.halotukozak.alpaca.plugin.settings.GrammarAssociation
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+private const val LEXER_ID = "BrainLexer.BrainLexer@L9"
+private const val PARSER_ID = "BrainParser.BrainParser@L12"
+
+/**
+ * The same [AlpacaFormattingModelBuilder] against a completely different grammar -- Brainfuck
+ * (plus named functions), whose only bracket kind is `[`/`]` and which has no comma, semicolon,
+ * or dot tokens at all -- with no code specific to either grammar. Complements
+ * [AlpacaFormattingModelBuilderTest], which uses `MathParser`'s `(`/`)`, `,`.
+ */
+class AlpacaFormattingModelBuilderBrainfuckTest : BasePlatformTestCase() {
+    override fun setUp() {
+        super.setUp()
+        val settings = AlpacaSettingsState.getInstance(project)
+        settings.exportDirectory = "/tmp/alpaca-grammar-export"
+        settings.associations =
+            mutableListOf(GrammarAssociation(extension = "bf", lexerGrammarId = LEXER_ID, parserGrammarId = PARSER_ID))
+        runWriteAction { AlpacaFileTypeRegistrar.ensureRegistered("bf", LEXER_ID) }
+    }
+
+    private fun reformat(text: String): String {
+        myFixture.configureByText("test.bf", text)
+        myFixture.performEditorAction("ReformatCode")
+        return myFixture.editor.document.text
+    }
+
+    fun `test a single-operation loop needs no spacing changes`() {
+        assertEquals("[+]", reformat("[+]"))
+    }
+
+    fun `test indents a wrapped loop body by one level`() {
+        val result = reformat("[\n+\n]")
+
+        assertEquals("[\n    +\n]", result)
+    }
+
+    fun `test spaces consecutive operations that have no special role`() {
+        // Brainfuck's own convention packs operations tight with no separators at all, but none
+        // of `+`/`-`/`>`/`<` is a bracket/comma/semicolon/dot, so they get the same generic
+        // default spacing as any other unclassified token pair -- a known tradeoff of having no
+        // per-grammar rules, not a bug specific to this grammar.
+        assertEquals("+ + +", reformat("+++"))
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilderTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilderTest.kt
@@ -30,26 +30,26 @@ class AlpacaFormattingModelBuilderTest : BasePlatformTestCase() {
         return myFixture.editor.document.text
     }
 
-    fun `test spaces an operator with no spaces around it`() {
-        assertEquals("1 + 2", reformat("1+2"))
-    }
-
-    fun `test collapses extra spaces around an operator to one`() {
-        assertEquals("1 + 2", reformat("1    +    2"))
+    fun `test leaves an operator's own spacing untouched`() {
+        // Nothing classifies "+" -- there is no generic "one space between tokens" fallback, so
+        // whatever spacing the user typed around an unclassified token survives verbatim.
+        assertEquals("1+2", reformat("1+2"))
+        assertEquals("1    +    2", reformat("1    +    2"))
     }
 
     fun `test removes space just inside a paren pair`() {
         assertEquals("(1 + 2)", reformat("( 1 + 2 )"))
     }
 
-    fun `test removes space before a comma but keeps one after it`() {
-        // atan2 is a keyword-shaped token like any other, so the generic default (one space
-        // between tokens with no special rule) still applies right before its own "(" -- the
-        // grammar-agnostic design has no notion of "function call" to special-case that away.
-        assertEquals("atan2 (1, 1)", reformat("atan2 ( 1 , 1 )"))
+    fun `test removes space before a comma but keeps whatever was after it`() {
+        // The " " between atan2 and "(" is unclassified and survives; the " " before the comma is
+        // removed; the "  " after the comma is unclassified and survives as-is.
+        assertEquals("atan2 (1,  1)", reformat("atan2 ( 1 ,  1 )"))
     }
 
     fun `test indents a wrapped paren group by one level and keeps the wrap`() {
+        // "tan(" (no space) is left alone, same as any other unclassified gap -- only the
+        // parens' own interior spacing and the wrapped Expr's indent are touched.
         val result =
             reformat(
                 """
@@ -61,7 +61,7 @@ class AlpacaFormattingModelBuilderTest : BasePlatformTestCase() {
 
         assertEquals(
             """
-            tan (
+            tan(
                 (1 + 2) * (3 - 4)
             )
             """.trimIndent(),
@@ -69,11 +69,13 @@ class AlpacaFormattingModelBuilderTest : BasePlatformTestCase() {
         )
     }
 
-    fun `test still applies the generic default spacing when the file's grammar is unresolved`() {
+    fun `test an unresolved grammar leaves the file untouched`() {
         // The extension is still registered as an Alpaca file type, but no association names a
         // grammar for it -- the same situation a stale or mistyped Settings entry would leave.
+        // FormattingRoles.of("<unresolved>", emptyList()) classifies nothing, so every gap is
+        // left alone; this only confirms that resolving no grammar doesn't crash the formatter.
         AlpacaSettingsState.getInstance(project).associations = mutableListOf()
 
-        assertEquals("1 + 2", reformat("1    +    2"))
+        assertEquals("( 1 , 1 )", reformat("( 1 , 1 )"))
     }
 }

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilderTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/formatting/AlpacaFormattingModelBuilderTest.kt
@@ -1,0 +1,79 @@
+package com.halotukozak.alpaca.plugin.formatting
+
+import com.halotukozak.alpaca.plugin.lexer.AlpacaFileTypeRegistrar
+import com.halotukozak.alpaca.plugin.settings.AlpacaSettingsState
+import com.halotukozak.alpaca.plugin.settings.GrammarAssociation
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+private const val LEXER_ID = "MathTest.CalcLexer@L11"
+private const val PARSER_ID = "MathTest.MathParser@L39"
+
+/**
+ * Exercises the real "Reformat Code" editor action against [AlpacaFormattingModelBuilder],
+ * registered for the real `MathParser` grammar (see the exported `MathTest.CalcLexer@L11.tokens.json`
+ * for its token shapes).
+ */
+class AlpacaFormattingModelBuilderTest : BasePlatformTestCase() {
+    override fun setUp() {
+        super.setUp()
+        val settings = AlpacaSettingsState.getInstance(project)
+        settings.exportDirectory = "/tmp/alpaca-grammar-export"
+        settings.associations =
+            mutableListOf(GrammarAssociation(extension = "calc", lexerGrammarId = LEXER_ID, parserGrammarId = PARSER_ID))
+        runWriteAction { AlpacaFileTypeRegistrar.ensureRegistered("calc", LEXER_ID) }
+    }
+
+    private fun reformat(text: String): String {
+        myFixture.configureByText("test.calc", text)
+        myFixture.performEditorAction("ReformatCode")
+        return myFixture.editor.document.text
+    }
+
+    fun `test spaces an operator with no spaces around it`() {
+        assertEquals("1 + 2", reformat("1+2"))
+    }
+
+    fun `test collapses extra spaces around an operator to one`() {
+        assertEquals("1 + 2", reformat("1    +    2"))
+    }
+
+    fun `test removes space just inside a paren pair`() {
+        assertEquals("(1 + 2)", reformat("( 1 + 2 )"))
+    }
+
+    fun `test removes space before a comma but keeps one after it`() {
+        // atan2 is a keyword-shaped token like any other, so the generic default (one space
+        // between tokens with no special rule) still applies right before its own "(" -- the
+        // grammar-agnostic design has no notion of "function call" to special-case that away.
+        assertEquals("atan2 (1, 1)", reformat("atan2 ( 1 , 1 )"))
+    }
+
+    fun `test indents a wrapped paren group by one level and keeps the wrap`() {
+        val result =
+            reformat(
+                """
+                tan(
+                (1 + 2) * (3 - 4)
+                )
+                """.trimIndent(),
+            )
+
+        assertEquals(
+            """
+            tan (
+                (1 + 2) * (3 - 4)
+            )
+            """.trimIndent(),
+            result,
+        )
+    }
+
+    fun `test still applies the generic default spacing when the file's grammar is unresolved`() {
+        // The extension is still registered as an Alpaca file type, but no association names a
+        // grammar for it -- the same situation a stale or mistyped Settings entry would leave.
+        AlpacaSettingsState.getInstance(project).associations = mutableListOf()
+
+        assertEquals("1 + 2", reformat("1    +    2"))
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/formatting/FormattingRolesTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/formatting/FormattingRolesTest.kt
@@ -1,0 +1,77 @@
+package com.halotukozak.alpaca.plugin.formatting
+
+import com.halotukozak.alpaca.plugin.grammar.BracketKind
+import com.halotukozak.alpaca.plugin.grammar.TokenSpec
+import com.halotukozak.alpaca.plugin.lexer.AlpacaTokenTypes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FormattingRolesTest {
+    private val grammarId = "formatting-roles-test"
+
+    private val tokens =
+        listOf(
+            TokenSpec("ws", "\\s+", ignored = true),
+            TokenSpec("lparen", "\\(", ignored = false),
+            TokenSpec("rparen", "\\)", ignored = false),
+            TokenSpec("lbracket", "\\[", ignored = false),
+            TokenSpec("rbracket", "\\]", ignored = false),
+            TokenSpec("comma", ",", ignored = false),
+            TokenSpec("semi", ";", ignored = false),
+            // Escaped, like a real grammar's member-access dot -- a bare `.` is the regex "any
+            // character" and (per BrainLexer's own catch-all ignored rule) not a literal dot.
+            TokenSpec("dot", "\\.", ignored = false),
+            TokenSpec("word", "[a-z]+", ignored = false),
+        )
+
+    private val roles = FormattingRoles.of(grammarId, tokens)
+
+    private fun typeOf(name: String) = AlpacaTokenTypes.forName(grammarId, name)
+
+    @Test
+    fun `classifies matching bracket pairs into openers and closers`() {
+        assertTrue(roles.openers.contains(typeOf("lparen")))
+        assertTrue(roles.openers.contains(typeOf("lbracket")))
+        assertTrue(roles.closers.contains(typeOf("rparen")))
+        assertTrue(roles.closers.contains(typeOf("rbracket")))
+        assertFalse(roles.openers.contains(typeOf("rparen")))
+        assertFalse(roles.closers.contains(typeOf("lparen")))
+    }
+
+    @Test
+    fun `roleOf reports the bracket kind and side`() {
+        val lparen = requireNotNull(roles.roleOf(typeOf("lparen")))
+        assertEquals(BracketKind.PARENTHESIS, lparen.kind)
+        assertTrue(lparen.opening)
+
+        val rbracket = requireNotNull(roles.roleOf(typeOf("rbracket")))
+        assertEquals(BracketKind.BRACKET, rbracket.kind)
+        assertFalse(rbracket.opening)
+    }
+
+    @Test
+    fun `classifies comma semicolon and dot tokens`() {
+        assertTrue(roles.commas.contains(typeOf("comma")))
+        assertTrue(roles.semicolons.contains(typeOf("semi")))
+        assertTrue(roles.dots.contains(typeOf("dot")))
+        assertFalse(roles.commas.contains(typeOf("semi")))
+    }
+
+    @Test
+    fun `leaves an identifier-shaped token unclassified`() {
+        assertNull(roles.roleOf(typeOf("word")))
+        assertFalse(roles.commas.contains(typeOf("word")))
+        assertFalse(roles.openers.contains(typeOf("word")))
+    }
+
+    @Test
+    fun `an empty token list classifies nothing`() {
+        val empty = FormattingRoles.of("formatting-roles-test-empty", emptyList())
+        assertNull(empty.roleOf(typeOf("lparen")))
+        assertTrue(empty.openers.types.isEmpty())
+        assertTrue(empty.commas.types.isEmpty())
+    }
+}


### PR DESCRIPTION
Roadmap step 4 — the tier-1 item flagged in the earlier research report as the biggest remaining UX gap. Alpaca-defined languages had no Reformat Code / auto-indent support at all.

## Design

Grammar-agnostic, like the rest of the plugin, and deliberately minimal — it only touches what it can justify structurally, and leaves everything else exactly as the user typed it:

- `FormattingRoles` classifies a resolved grammar's tokens purely by pattern **shape** (bracket / comma / semicolon / dot) — the same shapes `AlpacaBraceScanner` and `AlpacaSyntaxHighlighter` already key on. No per-grammar code.
- `AlpacaBlock` applies only:
  - no space just inside a bracket pair
  - no space before `,` / `;`, none around `.`
  - one indent level for whatever a matching bracket pair encloses
- **Anything else** — operator spacing, keyword-to-paren spacing, blank lines — `getSpacing` returns null and the formatter doesn't touch it.

There is **no** generic "one space between any two tokens" fallback. With no semantics, that would just be a different unfounded opinion: it made a keyword-shaped call `atan2(1, 1)` reformat to `atan2 (1, 1)`, and spaced a tight-packed grammar like Brainfuck's `+++` into `+ + +`. Both now pass through untouched.

Finding the bracket pair scans a node's direct children for a trailing closer with an earlier matching opener — not just "is the first child an opener" — otherwise a function-call shape like `tan` `(` `Expr` `)` wouldn't be recognized as bracketed (its first child is the keyword, not the paren).

## Testing

- `FormattingRolesTest` — pure classification logic.
- `AlpacaFormattingModelBuilderTest` — real "Reformat Code" action against `MathParser` (arithmetic, `(`/`)`/`,`): tight parens, comma spacing, wrapped-group indent, unclassified gaps left verbatim, and the unresolved-grammar fallback.
- `AlpacaFormattingModelBuilderBrainfuckTest` — same builder against an unrelated grammar (Brainfuck + named functions, only `[`/`]`, no comma/semicolon/dot at all).

Full plugin suite green; `ktlintCheck` clean. Stacked on `main` (after #562).

🤖 Generated with [Claude Code](https://claude.com/claude-code)