### PR TITLE
Feed TODO/FIXME scanning for Alpaca-defined languages

### DIFF
--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/todo/AlpacaIndexPatternBuilder.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/todo/AlpacaIndexPatternBuilder.kt
@@ -1,0 +1,66 @@
+package com.halotukozak.alpaca.plugin.todo
+
+import com.halotukozak.alpaca.plugin.grammar.lineCommentPrefixOf
+import com.halotukozak.alpaca.plugin.grammar.resolveGrammarForFile
+import com.halotukozak.alpaca.plugin.lexer.AlpacaLanguage
+import com.halotukozak.alpaca.plugin.lexer.AlpacaLexer
+import com.halotukozak.alpaca.plugin.lexer.AlpacaTokenTypes
+import com.intellij.lexer.Lexer
+import com.intellij.psi.PsiFile
+import com.intellij.psi.impl.search.IndexPatternBuilder
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.TokenSet
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Feeds `TODO`/`FIXME` (and any custom *Settings | Editor | TODO* pattern) scanning for
+ * Alpaca-defined languages, so those markers show up in the TODO tool window and the commit
+ * dialog's check.
+ *
+ * A "comment" here is an `ignored` token rule whose pattern has the `prefix.*` line-comment shape
+ * ([lineCommentPrefixOf]) -- the same rule [com.halotukozak.alpaca.plugin.commenter.AlpacaCommenter]
+ * uses, so an `ignored` whitespace rule like `[ \t\r\n]+` is not mistaken for a comment. The start
+ * delta strips the `#` / `//` / ... prefix so a marker still counts when written tight against it
+ * (`#TODO`).
+ */
+class AlpacaIndexPatternBuilder : IndexPatternBuilder {
+    // IElementType instances are per-(grammarId, ruleName) singletons (AlpacaTokenTypes), so this
+    // app-level map stays correct across grammars. Populated in getCommentTokenSet, which has the
+    // file; read back in the fileless getCommentStartDelta the platform calls per token.
+    private val prefixByCommentType = ConcurrentHashMap<IElementType, String>()
+
+    override fun getIndexingLexer(file: PsiFile): Lexer? {
+        val resolved = resolve(file) ?: return null
+        return AlpacaLexer(resolved.lexerId, resolved.tokens)
+    }
+
+    override fun getCommentTokenSet(file: PsiFile): TokenSet? {
+        val resolved = resolve(file) ?: return null
+        val commentTypes =
+            resolved.tokens.mapNotNull { spec ->
+                if (!spec.ignored) return@mapNotNull null
+                val prefix = lineCommentPrefixOf(spec.pattern) ?: return@mapNotNull null
+                AlpacaTokenTypes.forName(resolved.lexerId, spec.name).also { prefixByCommentType[it] = prefix }
+            }
+        return if (commentTypes.isEmpty()) null else TokenSet.create(*commentTypes.toTypedArray())
+    }
+
+    override fun getCommentStartDelta(tokenType: IElementType): Int = prefixByCommentType[tokenType]?.length ?: 0
+
+    override fun getCommentStartDelta(
+        tokenType: IElementType,
+        tokenText: CharSequence,
+    ): Int {
+        val prefix = prefixByCommentType[tokenType] ?: return 0
+        return if (tokenText.startsWith(prefix)) prefix.length else 0
+    }
+
+    override fun getCommentEndDelta(tokenType: IElementType): Int = 0
+
+    private fun resolve(file: PsiFile) =
+        if (file.language != AlpacaLanguage) {
+            null
+        } else {
+            (file.virtualFile ?: file.originalFile.virtualFile)?.let { resolveGrammarForFile(file.project, it) }
+        }
+}

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,7 @@
       <li><b>Reformat Code</b> that spaces and indents around your grammar's brackets, commas, semicolons,
         and dots, however they're spelled.</li>
       <li><b>Highlight occurrences</b> of the identifier under the caret, everywhere it appears in the file.</li>
+      <li><b>TODO markers</b> in comments feed the TODO tool window and the commit check.</li>
     </ul>
     <p>
       Point <b>Settings | Tools | Alpaca</b> at your grammar export directory and map file extensions
@@ -62,6 +63,7 @@
     <lang.commenter
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.commenter.AlpacaCommenter"/>
+    <indexPatternBuilder implementation="com.halotukozak.alpaca.plugin.todo.AlpacaIndexPatternBuilder"/>
     <lang.formatter
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.formatting.AlpacaFormattingModelBuilder"/>

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/todo/AlpacaIndexPatternBuilderTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/todo/AlpacaIndexPatternBuilderTest.kt
@@ -1,0 +1,90 @@
+package com.halotukozak.alpaca.plugin.todo
+
+import com.halotukozak.alpaca.plugin.lexer.AlpacaFileTypeRegistrar
+import com.halotukozak.alpaca.plugin.lexer.AlpacaTokenTypes
+import com.halotukozak.alpaca.plugin.settings.AlpacaSettingsState
+import com.halotukozak.alpaca.plugin.settings.GrammarAssociation
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.psi.search.PsiTodoSearchHelper
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+private const val CALC_LEXER_ID = "MathTest.CalcLexer@L11"
+private const val CALC_PARSER_ID = "MathTest.MathParser@L39"
+private const val BRAIN_LEXER_ID = "BrainLexer.BrainLexer@L9"
+private const val BRAIN_PARSER_ID = "BrainParser.BrainParser@L12"
+
+/**
+ * `MathTest`'s grammar has a `#.*` ignored rule (a line comment by shape); `BrainLexer`'s only
+ * ignored rules are `.` and `\n` (not comment-shaped). Exercises [AlpacaIndexPatternBuilder]
+ * against both, with no grammar-specific code.
+ */
+class AlpacaIndexPatternBuilderTest : BasePlatformTestCase() {
+    override fun setUp() {
+        super.setUp()
+        val settings = AlpacaSettingsState.getInstance(project)
+        settings.exportDirectory = "/tmp/alpaca-grammar-export"
+        settings.associations =
+            mutableListOf(
+                GrammarAssociation(extension = "calc", lexerGrammarId = CALC_LEXER_ID, parserGrammarId = CALC_PARSER_ID),
+                GrammarAssociation(extension = "bf", lexerGrammarId = BRAIN_LEXER_ID, parserGrammarId = BRAIN_PARSER_ID),
+            )
+        runWriteAction {
+            AlpacaFileTypeRegistrar.ensureRegistered("calc", CALC_LEXER_ID)
+            AlpacaFileTypeRegistrar.ensureRegistered("bf", BRAIN_LEXER_ID)
+        }
+    }
+
+    private fun todoTexts(
+        fileName: String,
+        text: String,
+    ): List<String> {
+        val file = myFixture.configureByText(fileName, text)
+        return PsiTodoSearchHelper
+            .getInstance(project)
+            .findTodoItemsLight(file)
+            .map { file.text.substring(it.textRange.startOffset, it.textRange.endOffset) }
+    }
+
+    fun `test finds a TODO inside a hash comment`() {
+        assertEquals(listOf("TODO fix precedence"), todoTexts("test.calc", "1 + 2 # TODO fix precedence"))
+    }
+
+    fun `test finds a marker written tight against the comment prefix`() {
+        // getCommentStartDelta strips the leading "#" so "#TODO" still matches.
+        assertEquals(listOf("TODO"), todoTexts("test.calc", "1 #TODO"))
+    }
+
+    fun `test also matches the built-in FIXME pattern`() {
+        assertEquals(listOf("FIXME later"), todoTexts("test.calc", "# FIXME later"))
+    }
+
+    fun `test a marker outside any comment is not a TODO`() {
+        assertEquals(emptyList<String>(), todoTexts("test.calc", "1 + 2"))
+    }
+
+    fun `test a grammar with no comment-shaped rule reports nothing`() {
+        // BrainLexer's ignored rules ("." and "\n") are not "prefix.*" -- getCommentTokenSet
+        // returns null, so there is no comment span for the scanner to look inside.
+        assertEquals(emptyList<String>(), todoTexts("test.bf", "+++ TODO"))
+    }
+
+    fun `test reports the prefix length as the comment start delta`() {
+        val builder = AlpacaIndexPatternBuilder()
+        val file = myFixture.configureByText("test.calc", "# TODO")
+        // Populates the builder's per-type prefix map; "#.*" is MathTest's line-comment rule.
+        builder.getCommentTokenSet(file)
+        val hashComment = AlpacaTokenTypes.forName(CALC_LEXER_ID, "#.*")
+
+        assertEquals(1, builder.getCommentStartDelta(hashComment))
+        assertEquals(1, builder.getCommentStartDelta(hashComment, "# TODO"))
+        assertEquals(0, builder.getCommentStartDelta(hashComment, "no hash here"))
+    }
+
+    fun `test contributes nothing to a non-Alpaca file`() {
+        val builder = AlpacaIndexPatternBuilder()
+        val file = myFixture.configureByText("plain.txt", "# TODO")
+
+        assertNull(builder.getIndexingLexer(file))
+        assertNull(builder.getCommentTokenSet(file))
+    }
+}


### PR DESCRIPTION
Roadmap Tier 1 item: TODO patterns (`IndexPatternBuilder`).

`TODO`/`FIXME` markers (and any custom *Settings | Editor | TODO* pattern) in comments now show up in the TODO tool window and the commit-dialog check.

## Changes
- `AlpacaIndexPatternBuilder`: lexes with the file's grammar lexer; a "comment" is an `ignored` rule whose pattern has the `prefix.*` line-comment shape (`lineCommentPrefixOf`) — the same rule `AlpacaCommenter` uses, so an `ignored` whitespace rule isn't treated as a comment. Start delta strips the `#`/`//`/… prefix.
- Grammars with no comment-shaped ignored rule contribute nothing (verified against Brainfuck).
- Registered via `<indexPatternBuilder>`.

## Coverage (`com.halotukozak.alpaca.plugin.todo`)
line 100%, method 100%, branch 81%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)