### PR TITLE
Auto-insert and skip-over matching quotes for string literals

### DIFF
--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaQuoteHandler.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaQuoteHandler.kt
@@ -1,0 +1,86 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.grammar.resolveGrammarForFile
+import com.halotukozak.alpaca.plugin.grammar.stringQuoteOf
+import com.intellij.codeInsight.editorActions.QuoteHandler
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.highlighter.HighlighterIterator
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.ProjectLocator
+
+/**
+ * "Insert pair quote" (and typing over a closing quote) for Alpaca-defined languages.
+ *
+ * The plugin registers one file type per grammar with a runtime-generated name, so this can't go
+ * through the file-type-keyed `quoteHandler` EP; it's a `lang.quoteHandler` on the shared
+ * [com.halotukozak.alpaca.plugin.lexer.AlpacaLanguage] instead, and works out per file whether the
+ * grammar even has string literals.
+ *
+ * A "string literal" is a highlighter token that starts with one of the quote characters the
+ * file's grammar actually uses for a string-shaped rule ([stringQuoteOf] -- the same shape
+ * [com.halotukozak.alpaca.plugin.lexer.AlpacaSyntaxHighlighter] paints as a string). A grammar
+ * with no such rule (a calculator, Brainfuck) resolves to an empty quote set and this handler
+ * stays completely inert.
+ */
+class AlpacaQuoteHandler : QuoteHandler {
+    override fun isOpeningQuote(
+        iterator: HighlighterIterator,
+        offset: Int,
+    ): Boolean = offset == iterator.start && startsStringLiteral(iterator.document, iterator.start)
+
+    override fun isClosingQuote(
+        iterator: HighlighterIterator,
+        offset: Int,
+    ): Boolean {
+        val chars = iterator.document.charsSequence
+        val start = iterator.start
+        val end = iterator.end
+        // A closed literal: opens and closes with the same quote, and the caret is on that close.
+        return end - start >= 2 &&
+            offset == end - 1 &&
+            startsStringLiteral(iterator.document, start) &&
+            chars[end - 1] == chars[start]
+    }
+
+    override fun hasNonClosedLiteral(
+        editor: Editor,
+        iterator: HighlighterIterator,
+        offset: Int,
+    ): Boolean {
+        val document = editor.document
+        val quotes = quoteChars(document)
+        if (quotes.isEmpty()) return false
+        val chars = document.charsSequence
+        val lineEnd = document.getLineEndOffset(document.getLineNumber(offset))
+        try {
+            while (!iterator.atEnd() && iterator.start < lineEnd) {
+                val start = iterator.start
+                if (start < chars.length && chars[start] in quotes) {
+                    if (iterator.end - start < 2 || chars[iterator.end - 1] != chars[start]) return true
+                }
+                iterator.advance()
+            }
+        } finally {
+            while (!iterator.atEnd() && iterator.start != offset) iterator.retreat()
+        }
+        return false
+    }
+
+    override fun isInsideLiteral(iterator: HighlighterIterator): Boolean = startsStringLiteral(iterator.document, iterator.start)
+
+    private fun startsStringLiteral(
+        document: Document,
+        offset: Int,
+    ): Boolean {
+        val chars = document.charsSequence
+        return offset in 0 until chars.length && chars[offset] in quoteChars(document)
+    }
+
+    private fun quoteChars(document: Document): Set<Char> {
+        val virtualFile = FileDocumentManager.getInstance().getFile(document) ?: return emptySet()
+        val project = ProjectLocator.getInstance().guessProjectForFile(virtualFile) ?: return emptySet()
+        val resolved = resolveGrammarForFile(project, virtualFile) ?: return emptySet()
+        return resolved.tokens.mapNotNullTo(HashSet()) { stringQuoteOf(it.pattern) }
+    }
+}

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/PatternShape.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/PatternShape.kt
@@ -51,6 +51,13 @@ fun bracketRoleOf(pattern: String): BracketRole? =
     }
 
 /**
+ * The quote character a string-literal rule is delimited by, inferred the same way
+ * [com.halotukozak.alpaca.plugin.lexer.AlpacaSyntaxHighlighter] infers the string color: the first
+ * `"` or `'` that appears literally in [pattern] (`"[^"]*"`, `'(\\.|[^'])*'`). Null if neither does.
+ */
+fun stringQuoteOf(pattern: String): Char? = pattern.firstOrNull { it == '"' || it == '\'' }
+
+/**
  * The fixed prefix [pattern] denotes for "prefix, then anything to end of line" (`#.*`, `//.*`,
  * ...), the shape Alpaca grammars typically use for line comments among their `ignored` rules.
  * Returns null for anything else.

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -24,6 +24,7 @@
         and dots, however they're spelled.</li>
       <li><b>Highlight occurrences</b> of the identifier under the caret, everywhere it appears in the file.</li>
       <li><b>TODO markers</b> in comments feed the TODO tool window and the commit check.</li>
+      <li><b>Pair-quote insertion</b> for grammars whose strings are delimited by <code>"</code> or <code>'</code>.</li>
     </ul>
     <p>
       Point <b>Settings | Tools | Alpaca</b> at your grammar export directory and map file extensions
@@ -48,6 +49,9 @@
     <heavyBracesHighlighter implementation="com.halotukozak.alpaca.plugin.editing.AlpacaBraceHighlighter"/>
     <highlightUsagesHandlerFactory
         implementation="com.halotukozak.alpaca.plugin.editing.AlpacaHighlightUsagesHandlerFactory"/>
+    <lang.quoteHandler
+        language="Alpaca"
+        implementationClass="com.halotukozak.alpaca.plugin.editing.AlpacaQuoteHandler"/>
     <lang.parserDefinition
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.parser.AlpacaParserDefinition"/>

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaQuoteHandlerTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaQuoteHandlerTest.kt
@@ -1,0 +1,82 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.lexer.AlpacaFileTypeRegistrar
+import com.halotukozak.alpaca.plugin.settings.AlpacaSettingsState
+import com.halotukozak.alpaca.plugin.settings.GrammarAssociation
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+private const val JSON_LEXER_ID = "JsonTest.JsonLexer@L13"
+private const val JSON_PARSER_ID = "JsonTest.JsonE2EParser@L33"
+private const val CALC_LEXER_ID = "MathTest.CalcLexer@L11"
+private const val CALC_PARSER_ID = "MathTest.MathParser@L39"
+
+/**
+ * `JsonTest`'s grammar has a `"(\\.|[^"])*"` String rule; `MathTest`'s has no string-shaped rule
+ * at all. Exercises [AlpacaQuoteHandler] through the real typed-quote editor action against both,
+ * with no grammar-specific code.
+ */
+class AlpacaQuoteHandlerTest : BasePlatformTestCase() {
+    override fun setUp() {
+        super.setUp()
+        val settings = AlpacaSettingsState.getInstance(project)
+        settings.exportDirectory = "/tmp/alpaca-grammar-export"
+        settings.associations =
+            mutableListOf(
+                GrammarAssociation(extension = "json", lexerGrammarId = JSON_LEXER_ID, parserGrammarId = JSON_PARSER_ID),
+                GrammarAssociation(extension = "calc", lexerGrammarId = CALC_LEXER_ID, parserGrammarId = CALC_PARSER_ID),
+            )
+        runWriteAction {
+            AlpacaFileTypeRegistrar.ensureRegistered("json", JSON_LEXER_ID)
+            AlpacaFileTypeRegistrar.ensureRegistered("calc", CALC_LEXER_ID)
+        }
+    }
+
+    private fun typeQuote(
+        fileName: String,
+        text: String,
+    ): String {
+        myFixture.configureByText(fileName, text)
+        myFixture.type('"')
+        return myFixture.editor.document.text
+    }
+
+    fun `test typing a quote auto-inserts the closing quote`() {
+        assertEquals("[\"\"]", typeQuote("test.json", "[<caret>]"))
+        assertEquals("caret sits between the inserted pair", 2, myFixture.editor.caretModel.offset)
+    }
+
+    fun `test typing a quote over the existing closing quote steps past it`() {
+        assertEquals("[\"\"]", typeQuote("test.json", "[\"<caret>\"]"))
+        assertEquals(3, myFixture.editor.caretModel.offset)
+    }
+
+    fun `test no auto-pair for a grammar without string tokens`() {
+        // MathTest has no string-shaped rule -> quoteChars is empty -> the handler is inert and
+        // the lone quote is just inserted as typed.
+        assertEquals("(\")", typeQuote("test.calc", "(<caret>)"))
+    }
+
+    fun `test typing a quote in the middle of a string just inserts it`() {
+        // Caret is inside the literal but not on either boundary: neither an opening nor a closing
+        // quote, and the char under the caret isn't a quote, so nothing special happens.
+        assertEquals("[\"fo\"o\"]", typeQuote("test.json", "[\"fo<caret>o\"]"))
+    }
+
+    fun `test typing a quote at the very end of the file still auto-pairs`() {
+        // No token to the right of the caret at all -- exercises the "offset is past the end of
+        // the document" guard in startsStringLiteral for the lookahead at the typed position.
+        assertEquals("\"\"", typeQuote("test.json", "<caret>"))
+    }
+
+    fun `test isInsideLiteral reports true only inside a string token`() {
+        myFixture.configureByText("test.json", "[\"abc\"]")
+        val iterator = (myFixture.editor as EditorEx).highlighter.createIterator(0)
+        val handler = AlpacaQuoteHandler()
+
+        assertFalse(handler.isInsideLiteral(iterator)) // positioned on "["
+        iterator.advance()
+        assertTrue(handler.isInsideLiteral(iterator)) // positioned on "abc"
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaQuoteHandlerTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaQuoteHandlerTest.kt
@@ -70,6 +70,14 @@ class AlpacaQuoteHandlerTest : BasePlatformTestCase() {
         assertEquals("\"\"", typeQuote("test.json", "<caret>"))
     }
 
+    fun `test typing an opening quote before a stray closing quote completes the literal`() {
+        // The typed quote plus the pre-existing trailing quote together already form a *closed*
+        // literal ("abc") -- hasNonClosedLiteral's scan must recognize that and skip past it
+        // rather than reporting the line as having an unclosed string, so no second closing quote
+        // gets inserted.
+        assertEquals("[\"abc\"]", typeQuote("test.json", "[<caret>abc\"]"))
+    }
+
     fun `test isInsideLiteral reports true only inside a string token`() {
         myFixture.configureByText("test.json", "[\"abc\"]")
         val iterator = (myFixture.editor as EditorEx).highlighter.createIterator(0)


### PR DESCRIPTION
Roadmap Tier 1 item: quote handler.

## Changes
- `AlpacaQuoteHandler` (`lang.quoteHandler` on the shared `AlpacaLanguage` — a file-type-keyed `quoteHandler` doesn't fit since file types are generated per grammar at runtime): a "string literal" is a highlighter token starting with a quote character the file's grammar actually uses for a string-shaped rule (`stringQuoteOf`, added to `PatternShape.kt` — the same shape `AlpacaSyntaxHighlighter` paints as a string).
- A grammar with no string-shaped rule (a calculator, Brainfuck) resolves to an empty quote set and the handler is completely inert — verified against `MathTest`.
- Tested against `JsonTest`'s grammar (a real `"(\.|[^"])*"` String rule): auto-pairs an opening quote, steps over an existing closing quote instead of inserting a second one, leaves a quote typed mid-literal alone, and recognizes when a typed opening quote plus a pre-existing trailing quote already complete a closed literal (so it doesn't double-close).

## Known scope limit (discussed, keeping as-is)
Only `"`/`'` are recognized as quote delimiters (matching `AlpacaSyntaxHighlighter`'s existing STRING heuristic) — a backtick/triple-quote/raw-string-prefixed literal isn't detected, same blind spot the highlighter already has for those shapes. Consistent trade-off, not a new gap.

## Coverage (`AlpacaQuoteHandler`)
line 100%, method 100%, branch 52% (up from 42%; remaining gaps are defensive branches in `hasNonClosedLiteral`'s scan loop and `quoteChars`'s null-project/file guards, consistent with the coverage level accepted elsewhere in this plugin for platform-driven callback code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)