### PR TITLE
Add breadcrumbs showing the caret's nesting path

### DIFF
--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProvider.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProvider.kt
@@ -6,8 +6,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.ui.breadcrumbs.BreadcrumbsProvider
 
-private const val SNIPPET_LIMIT = 24
-
 /**
  * Breadcrumbs (the path bar under the editor toolbar) for Alpaca-defined languages: one crumb per
  * composite node on the caret's ancestor chain, named after its own nonterminal.
@@ -16,6 +14,11 @@ private const val SNIPPET_LIMIT = 24
  * tokens of their own -- a composite node whose only child is another composite spanning the exact
  * same text range. Those would just repeat the same span at every level, so [acceptElement] skips
  * them; a node that adds even one token of its own (a bracket pair, a keyword) still gets a crumb.
+ *
+ * A crumb is just the nonterminal's name, with no text snippet: a snippet can run to a whole
+ * expression's worth of source, which reads as clutter in a bar meant to be scanned at a glance,
+ * and there's no shorter, reliably meaningful substring to prefer without semantics (no
+ * identifiers to key on).
  */
 class AlpacaBreadcrumbsProvider : BreadcrumbsProvider {
     override fun getLanguages(): Array<Language> = arrayOf(AlpacaLanguage)
@@ -26,10 +29,5 @@ class AlpacaBreadcrumbsProvider : BreadcrumbsProvider {
         return children.size != 1 || children[0].textRange != element.textRange
     }
 
-    override fun getElementInfo(element: PsiElement): String {
-        val typeName = element.node.elementType.toString()
-        val oneLine = element.text.replace('\n', ' ').trim()
-        val snippet = if (oneLine.length > SNIPPET_LIMIT) oneLine.take(SNIPPET_LIMIT) + "…" else oneLine
-        return if (snippet.isEmpty()) typeName else "$typeName: $snippet"
-    }
+    override fun getElementInfo(element: PsiElement): String = element.node.elementType.toString()
 }

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProvider.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProvider.kt
@@ -1,0 +1,35 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.lexer.AlpacaLanguage
+import com.intellij.lang.Language
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.ui.breadcrumbs.BreadcrumbsProvider
+
+private const val SNIPPET_LIMIT = 24
+
+/**
+ * Breadcrumbs (the path bar under the editor toolbar) for Alpaca-defined languages: one crumb per
+ * composite node on the caret's ancestor chain, named after its own nonterminal.
+ *
+ * An LR parse tree is full of unit-production chains (`Expr -> Term -> Factor -> ...`) that add no
+ * tokens of their own -- a composite node whose only child is another composite spanning the exact
+ * same text range. Those would just repeat the same span at every level, so [acceptElement] skips
+ * them; a node that adds even one token of its own (a bracket pair, a keyword) still gets a crumb.
+ */
+class AlpacaBreadcrumbsProvider : BreadcrumbsProvider {
+    override fun getLanguages(): Array<Language> = arrayOf(AlpacaLanguage)
+
+    override fun acceptElement(element: PsiElement): Boolean {
+        if (element is PsiFile || element.firstChild == null) return false
+        val children = element.children
+        return children.size != 1 || children[0].textRange != element.textRange
+    }
+
+    override fun getElementInfo(element: PsiElement): String {
+        val typeName = element.node.elementType.toString()
+        val oneLine = element.text.replace('\n', ' ').trim()
+        val snippet = if (oneLine.length > SNIPPET_LIMIT) oneLine.take(SNIPPET_LIMIT) + "…" else oneLine
+        return if (snippet.isEmpty()) typeName else "$typeName: $snippet"
+    }
+}

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -24,6 +24,7 @@
         and dots, however they're spelled.</li>
       <li><b>Highlight occurrences</b> of the identifier under the caret, everywhere it appears in the file.</li>
       <li><b>TODO markers</b> in comments feed the TODO tool window and the commit check.</li>
+      <li><b>Breadcrumbs</b> showing the caret's nesting path through the parsed tree.</li>
     </ul>
     <p>
       Point <b>Settings | Tools | Alpaca</b> at your grammar export directory and map file extensions
@@ -64,6 +65,7 @@
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.commenter.AlpacaCommenter"/>
     <indexPatternBuilder implementation="com.halotukozak.alpaca.plugin.todo.AlpacaIndexPatternBuilder"/>
+    <breadcrumbsInfoProvider implementation="com.halotukozak.alpaca.plugin.editing.AlpacaBreadcrumbsProvider"/>
     <lang.formatter
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.formatting.AlpacaFormattingModelBuilder"/>

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProviderTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProviderTest.kt
@@ -1,0 +1,72 @@
+package com.halotukozak.alpaca.plugin.editing
+
+import com.halotukozak.alpaca.plugin.lexer.AlpacaFileTypeRegistrar
+import com.halotukozak.alpaca.plugin.settings.AlpacaSettingsState
+import com.halotukozak.alpaca.plugin.settings.GrammarAssociation
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+private const val LEXER_ID = "MathTest.CalcLexer@L11"
+private const val PARSER_ID = "MathTest.MathParser@L39"
+
+/**
+ * MathParser's grammar has exactly two nonterminals, `Expr` and `root`, and every `Expr`
+ * alternative reduces to the same `Expr` element type (see [com.halotukozak.alpaca.plugin.parser.AlpacaLrDriver],
+ * which names composites after the production's LHS, not its per-alternative label) -- so the
+ * crumb chain below is entirely about which nodes [AlpacaBreadcrumbsProvider.acceptElement] keeps
+ * or drops, not about telling different rules apart.
+ */
+class AlpacaBreadcrumbsProviderTest : BasePlatformTestCase() {
+    private val provider = AlpacaBreadcrumbsProvider()
+
+    override fun setUp() {
+        super.setUp()
+        val settings = AlpacaSettingsState.getInstance(project)
+        settings.exportDirectory = "/tmp/alpaca-grammar-export"
+        settings.associations =
+            mutableListOf(GrammarAssociation(extension = "calc", lexerGrammarId = LEXER_ID, parserGrammarId = PARSER_ID))
+        runWriteAction { AlpacaFileTypeRegistrar.ensureRegistered("calc", LEXER_ID) }
+    }
+
+    /** Accepted crumb labels from the caret marked by `<caret>` in [text], innermost first. */
+    private fun crumbs(text: String): List<String> {
+        val file = myFixture.configureByText("test.calc", text)
+        val crumbs = mutableListOf<String>()
+        var element: PsiElement? = file.findElementAt(myFixture.caretOffset)
+        while (element != null && element !is PsiFile) {
+            if (provider.acceptElement(element)) crumbs += provider.getElementInfo(element)
+            element = provider.getParent(element)
+        }
+        return crumbs
+    }
+
+    fun `test skips the root's pure pass-through unit production`() {
+        // root -> Expr is a unit production (same text range as its Expr child): filtered. The
+        // literal-wrapping Expr around a single "int" token is not a unit production of another
+        // composite (the terminal is a leaf, invisible to PsiElement#getChildren), so it stays.
+        assertEquals(listOf("Expr: 42"), crumbs("<caret>42"))
+    }
+
+    fun `test keeps every level that adds its own tokens`() {
+        val result = crumbs("sin(<caret>1 + 2)")
+
+        assertEquals(
+            listOf(
+                "Expr: 1",
+                "Expr: 1 + 2",
+                "Expr: sin(1 + 2)",
+            ),
+            result,
+        )
+    }
+
+    fun `test truncates a long snippet with an ellipsis`() {
+        val result = crumbs("sin(<caret>1 + 222222222222222222)")
+
+        val outer = result.last()
+        assertTrue(outer.startsWith("Expr: sin(1 + 22222222"))
+        assertTrue(outer.endsWith("…"))
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProviderTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProviderTest.kt
@@ -46,27 +46,20 @@ class AlpacaBreadcrumbsProviderTest : BasePlatformTestCase() {
         // root -> Expr is a unit production (same text range as its Expr child): filtered. The
         // literal-wrapping Expr around a single "int" token is not a unit production of another
         // composite (the terminal is a leaf, invisible to PsiElement#getChildren), so it stays.
-        assertEquals(listOf("Expr: 42"), crumbs("<caret>42"))
+        assertEquals(listOf("Expr"), crumbs("<caret>42"))
     }
 
     fun `test keeps every level that adds its own tokens`() {
         val result = crumbs("sin(<caret>1 + 2)")
 
-        assertEquals(
-            listOf(
-                "Expr: 1",
-                "Expr: 1 + 2",
-                "Expr: sin(1 + 2)",
-            ),
-            result,
-        )
+        // Every level here is an Expr (see the class doc), so this is really asserting the depth:
+        // the literal, the "1 + 2" sum, and the outer sin(...) call each get their own crumb.
+        assertEquals(listOf("Expr", "Expr", "Expr"), result)
     }
 
-    fun `test truncates a long snippet with an ellipsis`() {
+    fun `test a crumb is just the nonterminal name, no source snippet`() {
         val result = crumbs("sin(<caret>1 + 222222222222222222)")
 
-        val outer = result.last()
-        assertTrue(outer.startsWith("Expr: sin(1 + 22222222"))
-        assertTrue(outer.endsWith("…"))
+        assertEquals(listOf("Expr", "Expr", "Expr"), result)
     }
 }


### PR DESCRIPTION
Roadmap Tier 1 item: breadcrumbs.

## Changes
- `AlpacaBreadcrumbsProvider` (`breadcrumbsInfoProvider`): one crumb per composite PSI node on the caret's ancestor chain, labeled with just its nonterminal name.
- `acceptElement` skips unit-production chains (`Expr -> Term -> Factor -> ...`) that add no tokens of their own — a node whose only composite child spans the exact same text range as itself. A node that adds even one token (a bracket pair, a keyword) still gets its own crumb, no matter which nonterminal or alternative produced it.
- (Update) Dropped the source-text snippet from crumb labels after trying it live — a whole expression's worth of text per tile reads as clutter in a bar meant to be scanned at a glance, and there's no shorter substring worth preferring without semantics (no identifiers to key on). A crumb is now just the nonterminal's name.

## Coverage (`AlpacaBreadcrumbsProvider`)
line 100%, method 100%, branch 80%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)