### PR TITLE
Label parsed nodes with their grammar production alternative

### DIFF
--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/hints/AlpacaParseTreeInlayHintsProvider.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/hints/AlpacaParseTreeInlayHintsProvider.kt
@@ -1,0 +1,91 @@
+package com.halotukozak.alpaca.plugin.hints
+
+import com.halotukozak.alpaca.plugin.grammar.ProductionSpec
+import com.halotukozak.alpaca.plugin.grammar.ResolvedGrammar
+import com.halotukozak.alpaca.plugin.grammar.SymbolSpec
+import com.halotukozak.alpaca.plugin.grammar.resolveGrammarForFile
+import com.halotukozak.alpaca.plugin.lexer.AlpacaLanguage
+import com.intellij.codeInsight.hints.declarative.HintFormat
+import com.intellij.codeInsight.hints.declarative.InlayHintsCollector
+import com.intellij.codeInsight.hints.declarative.InlayHintsProvider
+import com.intellij.codeInsight.hints.declarative.InlayTreeSink
+import com.intellij.codeInsight.hints.declarative.InlineInlayPosition
+import com.intellij.codeInsight.hints.declarative.SharedBypassCollector
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiWhiteSpace
+
+/**
+ * An inline hint at the start of each composite node, naming the *production alternative* that
+ * built it -- `plus` on `a + b`, `sin` on `sin(x)`, `atan2` on `atan2(y, x)`.
+ *
+ * Every alternative of a nonterminal reduces to the same PSI element type (see
+ * [com.halotukozak.alpaca.plugin.parser.AlpacaLrDriver], which names composites after the
+ * production's LHS, not its per-alternative label), so the alternative that actually matched is
+ * nowhere on the node itself -- only in `<parser>.productions.json`. This recovers it by matching
+ * the node's own child-symbol sequence back against that grammar's productions. Fully
+ * grammar-agnostic: both the label and the match come from the exported data.
+ *
+ * Only multi-symbol alternatives (`rhs.size >= 2`) are labelled. A single-nonterminal production
+ * is an LR unit-production artifact (`Expr -> Term -> Factor`); a single-terminal one
+ * (`Expr -> int`) says no more than the token already visible under the hint. Labelling either
+ * would just be noise.
+ */
+class AlpacaParseTreeInlayHintsProvider : InlayHintsProvider {
+    override fun createCollector(
+        file: PsiFile,
+        editor: Editor,
+    ): InlayHintsCollector? {
+        if (file.language != AlpacaLanguage) return null
+        val virtualFile = file.virtualFile ?: return null
+        val resolved = resolveGrammarForFile(file.project, virtualFile) ?: return null
+        if (resolved.parserGrammar?.productions?.any { it.isLabelledAlternative } != true) return null
+        return Collector(resolved)
+    }
+
+    private class Collector(
+        resolved: ResolvedGrammar,
+    ) : SharedBypassCollector {
+        private val productions = resolved.parserGrammar!!.productions
+        private val ignoredTokenNames =
+            resolved.tokens
+                .asSequence()
+                .filter { it.ignored }
+                .map { it.name }
+                .toSet()
+
+        override fun collectFromElement(
+            element: PsiElement,
+            sink: InlayTreeSink,
+        ) {
+            if (element is PsiFile || element.firstChild == null) return
+            val label = alternativeLabelFor(element) ?: return
+            sink.addPresentation(
+                InlineInlayPosition(element.textRange.startOffset, relatedToPrevious = false),
+                hintFormat = HintFormat.default,
+            ) { text(label) }
+        }
+
+        private fun alternativeLabelFor(element: PsiElement): String? {
+            val lhs = element.node.elementType.toString()
+            val candidates = productions.filter { it.lhs == lhs && it.isLabelledAlternative }
+            if (candidates.isEmpty()) return null
+
+            val childSymbols =
+                element.node
+                    .getChildren(null)
+                    .map { it.psi }
+                    .filterNot { it is PsiWhiteSpace || it is PsiComment || it is PsiErrorElement }
+                    .map { it.node.elementType.toString() }
+                    .filterNot { it in ignoredTokenNames }
+
+            return candidates.singleOrNull { it.rhs.map(SymbolSpec::name) == childSymbols }?.name
+        }
+    }
+}
+
+private val ProductionSpec.isLabelledAlternative: Boolean
+    get() = name != null && rhs.size >= 2

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -27,6 +27,7 @@
       <li><b>Breadcrumbs</b> showing the caret's nesting path through the parsed tree.</li>
       <li><b>Quick Documentation</b> (hover / Ctrl+Q) showing a token's pattern or a nonterminal's
         full set of production alternatives.</li>
+      <li><b>Inlay hints</b> labelling each parsed node with the grammar production alternative that built it.</li>
     </ul>
     <p>
       Point <b>Settings | Tools | Alpaca</b> at your grammar export directory and map file extensions
@@ -36,6 +37,8 @@
   ]]></description>
 
   <depends>com.intellij.modules.platform</depends>
+
+  <resource-bundle>messages.AlpacaBundle</resource-bundle>
 
   <extensions defaultExtensionNs="com.intellij">
     <postStartupActivity implementation="com.halotukozak.alpaca.plugin.startup.AlpacaGrammarStartupActivity"/>
@@ -74,6 +77,14 @@
     <lang.formatter
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.formatting.AlpacaFormattingModelBuilder"/>
+    <codeInsight.declarativeInlayProvider
+        language="Alpaca"
+        providerId="alpaca.parseTree"
+        isEnabledByDefault="true"
+        group="OTHER_GROUP"
+        nameKey="inlay.alpaca.parseTree.name"
+        descriptionKey="inlay.alpaca.parseTree.description"
+        implementationClass="com.halotukozak.alpaca.plugin.hints.AlpacaParseTreeInlayHintsProvider"/>
     <notificationGroup id="Alpaca" displayType="BALLOON"/>
   </extensions>
 

--- a/ij-plugin/src/main/resources/messages/AlpacaBundle.properties
+++ b/ij-plugin/src/main/resources/messages/AlpacaBundle.properties
@@ -1,0 +1,2 @@
+inlay.alpaca.parseTree.name=Grammar production alternatives
+inlay.alpaca.parseTree.description=Labels each parsed node with the production alternative that built it (e.g. plus, sin), recovered from the grammar's exported productions. The PSI only records a node's left-hand nonterminal, so the alternative is otherwise invisible on the node itself.

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/hints/AlpacaParseTreeInlayHintsProviderTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/hints/AlpacaParseTreeInlayHintsProviderTest.kt
@@ -1,0 +1,123 @@
+package com.halotukozak.alpaca.plugin.hints
+
+import com.halotukozak.alpaca.plugin.lexer.AlpacaFileTypeRegistrar
+import com.halotukozak.alpaca.plugin.settings.AlpacaSettingsState
+import com.halotukozak.alpaca.plugin.settings.GrammarAssociation
+import com.intellij.codeInsight.hints.declarative.CollapseState
+import com.intellij.codeInsight.hints.declarative.CollapsiblePresentationTreeBuilder
+import com.intellij.codeInsight.hints.declarative.HintFormat
+import com.intellij.codeInsight.hints.declarative.InlayActionData
+import com.intellij.codeInsight.hints.declarative.InlayPayload
+import com.intellij.codeInsight.hints.declarative.InlayPosition
+import com.intellij.codeInsight.hints.declarative.InlayTreeSink
+import com.intellij.codeInsight.hints.declarative.InlineInlayPosition
+import com.intellij.codeInsight.hints.declarative.PresentationTreeBuilder
+import com.intellij.codeInsight.hints.declarative.SharedBypassCollector
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+private const val LEXER_ID = "MathTest.CalcLexer@L11"
+private const val PARSER_ID = "MathTest.MathParser@L39"
+
+/**
+ * Drives [AlpacaParseTreeInlayHintsProvider]'s collector over a real MathParser PSI tree. MathParser
+ * names every `Expr` alternative (`plus`, `sin`, `atan2`, ...) but its bare-literal alternatives
+ * (`Expr -> int`, `Expr -> ( Expr )` is unnamed) are single-symbol or unnamed, so only the
+ * operator/function nodes get a hint.
+ */
+class AlpacaParseTreeInlayHintsProviderTest : BasePlatformTestCase() {
+    private val provider = AlpacaParseTreeInlayHintsProvider()
+
+    override fun setUp() {
+        super.setUp()
+        val settings = AlpacaSettingsState.getInstance(project)
+        settings.exportDirectory = "/tmp/alpaca-grammar-export"
+        settings.associations =
+            mutableListOf(GrammarAssociation(extension = "calc", lexerGrammarId = LEXER_ID, parserGrammarId = PARSER_ID))
+        runWriteAction { AlpacaFileTypeRegistrar.ensureRegistered("calc", LEXER_ID) }
+    }
+
+    /** Every hint the provider emits for [text], as `offset to label`, in document order. */
+    private fun hints(text: String): List<Pair<Int, String>> {
+        val file = myFixture.configureByText("test.calc", text)
+        val collector =
+            provider.createCollector(file, myFixture.editor) as? SharedBypassCollector
+                ?: return emptyList()
+        val sink = RecordingSink()
+        PsiTreeUtil.processElements(file) {
+            collector.collectFromElement(it, sink)
+            true
+        }
+        return sink.hints.sortedBy { it.first }
+    }
+
+    fun `test labels a binary operator node with its production alternative`() {
+        assertEquals(listOf(0 to "plus"), hints("1 + 2"))
+    }
+
+    fun `test labels nested operators, innermost included`() {
+        // `1 + 2 * 3` parses as plus(1, times(2, 3)); both operator nodes are labelled, the bare
+        // int literals are not (Expr -> int is a single-symbol alternative).
+        assertEquals(listOf(0 to "plus", 4 to "times"), hints("1 + 2 * 3"))
+    }
+
+    fun `test labels a function-call node`() {
+        assertEquals(listOf(0 to "sin", 4 to "plus"), hints("sin(1 + 2)"))
+    }
+
+    fun `test no hints when the file's grammar has no parser association`() {
+        AlpacaSettingsState.getInstance(project).associations =
+            mutableListOf(GrammarAssociation(extension = "calc", lexerGrammarId = LEXER_ID, parserGrammarId = ""))
+
+        assertEquals(emptyList<Pair<Int, String>>(), hints("1 + 2"))
+    }
+
+    fun `test no collector outside an Alpaca language`() {
+        val file = myFixture.configureByText("plain.txt", "1 + 2")
+
+        assertNull(provider.createCollector(file, myFixture.editor))
+    }
+
+    private class RecordingSink : InlayTreeSink {
+        val hints = mutableListOf<Pair<Int, String>>()
+
+        override fun addPresentation(
+            position: InlayPosition,
+            payloads: List<InlayPayload>?,
+            tooltip: String?,
+            hintFormat: HintFormat,
+            builder: PresentationTreeBuilder.() -> Unit,
+        ) {
+            val offset = (position as InlineInlayPosition).offset
+            RecordingTreeBuilder { hints += offset to it }.builder()
+        }
+
+        override fun whenOptionEnabled(
+            optionId: String,
+            block: () -> Unit,
+        ) = block()
+    }
+
+    private class RecordingTreeBuilder(
+        private val onText: (String) -> Unit,
+    ) : PresentationTreeBuilder {
+        override fun text(
+            text: String,
+            actionData: InlayActionData?,
+        ) = onText(text)
+
+        override fun list(builder: PresentationTreeBuilder.() -> Unit) = builder()
+
+        override fun collapsibleList(
+            state: CollapseState,
+            expandedState: CollapsiblePresentationTreeBuilder.() -> Unit,
+            collapsedState: CollapsiblePresentationTreeBuilder.() -> Unit,
+        ) = Unit
+
+        override fun clickHandlerScope(
+            actionData: InlayActionData,
+            builder: PresentationTreeBuilder.() -> Unit,
+        ) = builder()
+    }
+}


### PR DESCRIPTION
## Summary

Adds a declarative inlay hints provider (Tier 1 roadmap item, no grammar-export change) that labels each parsed composite node with the **production alternative** that built it — `plus` on `a + b`, `sin` on `sin(x)`, `atan2` on `atan2(y, x)`.

Every alternative of a nonterminal reduces to the same PSI element type (`AlpacaLrDriver` names composites after the production's LHS, not its per-alternative label), so the matched alternative is otherwise invisible on the node — it only exists in `<parser>.productions.json`. The provider recovers it by matching a node's own child-symbol sequence back against the grammar's productions for that LHS. Fully grammar-agnostic.

- Only multi-symbol alternatives (`rhs.size >= 2`) are labelled: a single-nonterminal production is an LR unit-production artifact, and a single-terminal one says nothing the token under the hint doesn't already.
- Enabled by default; toggled per-language under Settings | Editor | Inlay Hints | Other.
- New `messages/AlpacaBundle.properties` + `<resource-bundle>` (first message bundle in the plugin), required by the declarative inlay EP for its settings-page name/description.

## Test plan

- [x] `AlpacaParseTreeInlayHintsProviderTest` — drives the real collector over MathParser PSI trees (`1 + 2` → `plus`; `1 + 2 * 3` → `plus`/`times`; `sin(1 + 2)` → `sin`/`plus`; no parser association → nothing; non-Alpaca file → no collector)
- [x] full `./gradlew ktlintCheck test` green
- [ ] live in sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)