### PR TITLE
Label breadcrumbs with the production alternative, not the nonterminal

### DIFF
--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProvider.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProvider.kt
@@ -1,5 +1,7 @@
 package com.halotukozak.alpaca.plugin.editing
 
+import com.halotukozak.alpaca.plugin.grammar.matchedAlternativeName
+import com.halotukozak.alpaca.plugin.grammar.resolveGrammarForFile
 import com.halotukozak.alpaca.plugin.lexer.AlpacaLanguage
 import com.intellij.lang.Language
 import com.intellij.psi.PsiElement
@@ -8,17 +10,21 @@ import com.intellij.ui.breadcrumbs.BreadcrumbsProvider
 
 /**
  * Breadcrumbs (the path bar under the editor toolbar) for Alpaca-defined languages: one crumb per
- * composite node on the caret's ancestor chain, named after its own nonterminal.
+ * composite node on the caret's ancestor chain.
  *
  * An LR parse tree is full of unit-production chains (`Expr -> Term -> Factor -> ...`) that add no
  * tokens of their own -- a composite node whose only child is another composite spanning the exact
  * same text range. Those would just repeat the same span at every level, so [acceptElement] skips
  * them; a node that adds even one token of its own (a bracket pair, a keyword) still gets a crumb.
  *
- * A crumb is just the nonterminal's name, with no text snippet: a snippet can run to a whole
- * expression's worth of source, which reads as clutter in a bar meant to be scanned at a glance,
- * and there's no shorter, reliably meaningful substring to prefer without semantics (no
- * identifiers to key on).
+ * A crumb is labelled with the *production alternative* that built it (`plus`, `sin`), not its
+ * nonterminal: every alternative of a nonterminal reduces to the same element type (see
+ * [com.halotukozak.alpaca.plugin.parser.AlpacaLrDriver]), so a chain of crumbs would otherwise
+ * often repeat the same nonterminal name at every level (`Expr > Expr > Expr`) -- exactly the kind
+ * of unhelpful, hard-to-scan breadcrumb this provider exists to avoid. The nonterminal name is
+ * still the fallback when an alternative has no name or none matches uniquely (see
+ * [matchedAlternativeName]) -- unlike Structure View, which shows the nonterminal as the primary,
+ * always-present category.
  */
 class AlpacaBreadcrumbsProvider : BreadcrumbsProvider {
     override fun getLanguages(): Array<Language> = arrayOf(AlpacaLanguage)
@@ -29,5 +35,10 @@ class AlpacaBreadcrumbsProvider : BreadcrumbsProvider {
         return children.size != 1 || children[0].textRange != element.textRange
     }
 
-    override fun getElementInfo(element: PsiElement): String = element.node.elementType.toString()
+    override fun getElementInfo(element: PsiElement): String {
+        val nonterminal = element.node.elementType.toString()
+        val virtualFile = element.containingFile?.virtualFile ?: return nonterminal
+        val resolved = resolveGrammarForFile(element.project, virtualFile) ?: return nonterminal
+        return matchedAlternativeName(element, resolved) ?: nonterminal
+    }
 }

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/ProductionMatching.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/ProductionMatching.kt
@@ -1,0 +1,44 @@
+package com.halotukozak.alpaca.plugin.grammar
+
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
+import com.intellij.psi.PsiWhiteSpace
+
+/**
+ * The production alternative that built [element], if its own child-symbol sequence uniquely
+ * matches exactly one *named* alternative of its nonterminal in [resolved]'s exported grammar;
+ * `null` if there's no parser grammar, no alternative is named, or none matches uniquely.
+ *
+ * Every alternative of a nonterminal reduces to the same PSI element type ([AlpacaLrDriver][
+ * com.halotukozak.alpaca.plugin.parser.AlpacaLrDriver] names composites after the production's
+ * LHS, not its per-alternative label), so which one actually matched a given node is otherwise
+ * nowhere on the node itself -- only in `<parser>.productions.json`. This recovers it by comparing
+ * the node's own child symbols (its composite children's element types and its leaf children's
+ * token names, ignored/whitespace/error children skipped) against each same-LHS production's `rhs`.
+ */
+fun matchedAlternativeName(
+    element: PsiElement,
+    resolved: ResolvedGrammar,
+): String? {
+    val grammar = resolved.parserGrammar ?: return null
+    val lhs = element.node.elementType.toString()
+    val candidates = grammar.productions.filter { it.lhs == lhs && it.name != null }
+    if (candidates.isEmpty()) return null
+
+    val ignoredTokenNames =
+        resolved.tokens
+            .asSequence()
+            .filter { it.ignored }
+            .map { it.name }
+            .toSet()
+    val childSymbols =
+        element.node
+            .getChildren(null)
+            .map { it.psi }
+            .filterNot { it is PsiWhiteSpace || it is PsiComment || it is PsiErrorElement }
+            .map { it.node.elementType.toString() }
+            .filterNot { it in ignoredTokenNames }
+
+    return candidates.singleOrNull { it.rhs.map(SymbolSpec::name) == childSymbols }?.name
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProviderTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/editing/AlpacaBreadcrumbsProviderTest.kt
@@ -12,11 +12,13 @@ private const val LEXER_ID = "MathTest.CalcLexer@L11"
 private const val PARSER_ID = "MathTest.MathParser@L39"
 
 /**
- * MathParser's grammar has exactly two nonterminals, `Expr` and `root`, and every `Expr`
- * alternative reduces to the same `Expr` element type (see [com.halotukozak.alpaca.plugin.parser.AlpacaLrDriver],
- * which names composites after the production's LHS, not its per-alternative label) -- so the
- * crumb chain below is entirely about which nodes [AlpacaBreadcrumbsProvider.acceptElement] keeps
- * or drops, not about telling different rules apart.
+ * Every `Expr` alternative in MathParser's grammar reduces to the same `Expr` element type (see
+ * [com.halotukozak.alpaca.plugin.parser.AlpacaLrDriver], which names composites after the
+ * production's LHS, not its per-alternative label) -- so a crumb chain naming just the nonterminal
+ * would repeat "Expr" at every level. [AlpacaBreadcrumbsProvider.getElementInfo] instead labels
+ * each crumb with the *production alternative* that built it (`plus`, `sin`), recovered via
+ * [com.halotukozak.alpaca.plugin.grammar.matchedAlternativeName]; the nonterminal is only the
+ * fallback for an alternative with no name (`Expr -> int` is unnamed).
  */
 class AlpacaBreadcrumbsProviderTest : BasePlatformTestCase() {
     private val provider = AlpacaBreadcrumbsProvider()
@@ -46,20 +48,32 @@ class AlpacaBreadcrumbsProviderTest : BasePlatformTestCase() {
         // root -> Expr is a unit production (same text range as its Expr child): filtered. The
         // literal-wrapping Expr around a single "int" token is not a unit production of another
         // composite (the terminal is a leaf, invisible to PsiElement#getChildren), so it stays.
+        // Expr -> int is unnamed, so the crumb falls back to the nonterminal.
         assertEquals(listOf("Expr"), crumbs("<caret>42"))
     }
 
-    fun `test keeps every level that adds its own tokens`() {
+    fun `test labels each crumb with its production alternative, innermost first`() {
         val result = crumbs("sin(<caret>1 + 2)")
 
-        // Every level here is an Expr (see the class doc), so this is really asserting the depth:
-        // the literal, the "1 + 2" sum, and the outer sin(...) call each get their own crumb.
-        assertEquals(listOf("Expr", "Expr", "Expr"), result)
+        // The literal falls back to "Expr" (Expr -> int is unnamed); the sum and the call each
+        // have a named alternative, so they're distinguishable from one another and from the
+        // literal -- unlike before, when every level here was indistinguishably "Expr".
+        assertEquals(listOf("Expr", "plus", "sin"), result)
     }
 
-    fun `test a crumb is just the nonterminal name, no source snippet`() {
+    fun `test a crumb is just the label, no source snippet`() {
         val result = crumbs("sin(<caret>1 + 222222222222222222)")
 
-        assertEquals(listOf("Expr", "Expr", "Expr"), result)
+        assertEquals(listOf("Expr", "plus", "sin"), result)
+    }
+
+    fun `test no crumbs when the file's grammar has no parser association`() {
+        AlpacaSettingsState.getInstance(project).associations =
+            mutableListOf(GrammarAssociation(extension = "calc", lexerGrammarId = LEXER_ID, parserGrammarId = ""))
+
+        // With no parser configured, AlpacaFileElementType never runs the LR driver: there's no
+        // Expr wrapper at all, just the bare token directly under the file -- nothing for
+        // acceptElement to keep.
+        assertEquals(emptyList<String>(), crumbs("<caret>1"))
     }
 }

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/grammar/ProductionMatchingTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/grammar/ProductionMatchingTest.kt
@@ -1,0 +1,61 @@
+package com.halotukozak.alpaca.plugin.grammar
+
+import com.halotukozak.alpaca.plugin.lexer.AlpacaFileTypeRegistrar
+import com.halotukozak.alpaca.plugin.settings.AlpacaSettingsState
+import com.halotukozak.alpaca.plugin.settings.GrammarAssociation
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+private const val LEXER_ID = "MathTest.CalcLexer@L11"
+private const val PARSER_ID = "MathTest.MathParser@L39"
+
+/**
+ * Exercises [matchedAlternativeName] directly against MathParser's real exported grammar, ahead
+ * of any UI surface using it (currently [com.halotukozak.alpaca.plugin.editing.AlpacaBreadcrumbsProvider]).
+ */
+class ProductionMatchingTest : BasePlatformTestCase() {
+    override fun setUp() {
+        super.setUp()
+        val settings = AlpacaSettingsState.getInstance(project)
+        settings.exportDirectory = "/tmp/alpaca-grammar-export"
+        settings.associations =
+            mutableListOf(GrammarAssociation(extension = "calc", lexerGrammarId = LEXER_ID, parserGrammarId = PARSER_ID))
+        runWriteAction { AlpacaFileTypeRegistrar.ensureRegistered("calc", LEXER_ID) }
+    }
+
+    /**
+     * Matches the top-level `Expr` parsed from [text]: `root -> Expr` is always a unit production
+     * (unnamed, same text range as its child), so `root`'s one composite child is the actual
+     * outermost expression -- e.g. for `"1 + 2"` this is the `plus` node, not the `int`-literal
+     * node the first token's own PSI parent would give (that leaf is nested one level deeper).
+     */
+    private fun matchOutermost(text: String): String? {
+        val file = myFixture.configureByText("test.calc", text)
+        val resolved = resolveGrammarForFile(project, file.virtualFile)!!
+        val root = file.children.single()
+        val outermostExpr = root.children.single()
+        return matchedAlternativeName(outermostExpr, resolved)
+    }
+
+    fun `test matches a binary operator alternative`() {
+        assertEquals("plus", matchOutermost("1 + 2"))
+    }
+
+    fun `test matches a function-call alternative`() {
+        assertEquals("sin", matchOutermost("sin(1)"))
+    }
+
+    fun `test returns null for an unnamed alternative`() {
+        // Expr -> int has no name in MathParser's grammar.
+        assertNull(matchOutermost("42"))
+    }
+
+    fun `test returns null when the file's grammar has no parser association`() {
+        AlpacaSettingsState.getInstance(project).associations =
+            mutableListOf(GrammarAssociation(extension = "calc", lexerGrammarId = LEXER_ID, parserGrammarId = ""))
+        val file = myFixture.configureByText("test.calc", "1")
+        val resolved = resolveGrammarForFile(project, file.virtualFile)!!
+
+        assertNull(matchedAlternativeName(file.findElementAt(0)!!.parent, resolved))
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the discussion on #578 (closed): every alternative of a nonterminal reduces to the same PSI element type, so labelling a breadcrumb with just the nonterminal often repeats the same name at every level (`Expr > Expr > Expr` for MathParser) — exactly the unhelpful, hard-to-scan breadcrumb this provider exists to avoid.

- Breadcrumbs now show the **production alternative** that built each node (`plus`, `sin`), recovered by matching the node's own child-symbol sequence back against the grammar's productions for its nonterminal. Falls back to the nonterminal when an alternative has no name, or none matches uniquely.
- Structure View is intentionally left alone: it shows the nonterminal as the primary, always-present category (`object`, `array`, ... for a real grammar), which is the right level for browsing a parse tree. The alternative name is a secondary, per-node detail, not a replacement.
- The alternative-matching logic (`grammar/ProductionMatching.kt`) is extracted as a standalone, directly-tested helper rather than living inside the breadcrumbs provider, since it's reusable (originally written for an inline inlay-hints prototype in #578, closed as redundant/noisy once this landed).

## Test plan

- [x] `ProductionMatchingTest` — direct unit coverage of the matching helper (binary operator, function call, unnamed alternative, no parser association)
- [x] `AlpacaBreadcrumbsProviderTest` — updated for the new labels, plus a case with no parser association
- [x] full `./gradlew ktlintCheck test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)