### PR TITLE
Add an Alpaca Grammar tool window browsing the current file's whole grammar

### DIFF
--- a/ij-plugin/build.gradle.kts
+++ b/ij-plugin/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 
 plugins {
     id("org.jetbrains.kotlin.jvm") version "2.4.20"
@@ -33,6 +34,15 @@ dependencies {
 
 kotlin {
     jvmToolchain(21)
+    compilerOptions {
+        // Kotlin's default ("enable") emits a compatibility bridge in every implementing class for
+        // each default method of an implemented interface -- including ones we never touch. Several
+        // IntelliJ Platform interfaces (e.g. ToolWindowFactory) have default methods marked
+        // @ApiStatus.Internal; those bridges alone trip the Plugin Verifier's INTERNAL_API_USAGES
+        // check even though our code never calls or overrides them. This plugin has no Kotlin
+        // caller-compatibility surface to preserve, so no-compatibility (skip the bridges) is safe.
+        jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
+    }
 }
 
 intellijPlatform {

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/documentation/AlpacaDocumentationProvider.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/documentation/AlpacaDocumentationProvider.kt
@@ -2,10 +2,9 @@ package com.halotukozak.alpaca.plugin.documentation
 
 import com.halotukozak.alpaca.plugin.grammar.ProductionSpec
 import com.halotukozak.alpaca.plugin.grammar.ResolvedGrammar
-import com.halotukozak.alpaca.plugin.grammar.SymbolSpec
 import com.halotukozak.alpaca.plugin.grammar.TokenSpec
-import com.halotukozak.alpaca.plugin.grammar.literalTextOf
 import com.halotukozak.alpaca.plugin.grammar.resolveGrammarForFile
+import com.halotukozak.alpaca.plugin.grammar.symbolLabel
 import com.halotukozak.alpaca.plugin.lexer.AlpacaLanguage
 import com.intellij.lang.documentation.AbstractDocumentationProvider
 import com.intellij.lang.documentation.DocumentationMarkup
@@ -99,15 +98,5 @@ class AlpacaDocumentationProvider : AbstractDocumentationProvider() {
             }
         val label = production.name?.let { " <i>(${StringUtil.escapeXmlEntities(it)})</i>" }.orEmpty()
         return "${StringUtil.escapeXmlEntities(production.lhs)} &rarr; $rhs$label<br>"
-    }
-
-    private fun symbolLabel(
-        symbol: SymbolSpec,
-        tokens: List<TokenSpec>,
-    ): String {
-        if (symbol.kind != "terminal") return symbol.name
-        val pattern = tokens.firstOrNull { it.name == symbol.name }?.pattern
-        val literal = pattern?.let(::literalTextOf)
-        return if (literal != null) "'$literal'" else symbol.name
     }
 }

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/SymbolLabel.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/SymbolLabel.kt
@@ -1,0 +1,17 @@
+package com.halotukozak.alpaca.plugin.grammar
+
+/**
+ * A human-readable label for [symbol]: its fixed spelling in single quotes when [tokens] resolves
+ * it to one (`'+'`, `'('`), or its bare rule name otherwise (a nonterminal, or a terminal with no
+ * single fixed spelling, e.g. `int`). Shared by every surface that spells out a production's
+ * right-hand side (Quick Documentation, the grammar tool window).
+ */
+fun symbolLabel(
+    symbol: SymbolSpec,
+    tokens: List<TokenSpec>,
+): String {
+    if (symbol.kind != "terminal") return symbol.name
+    val pattern = tokens.firstOrNull { it.name == symbol.name }?.pattern
+    val literal = pattern?.let(::literalTextOf)
+    return if (literal != null) "'$literal'" else symbol.name
+}

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/AlpacaGrammarToolWindowFactory.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/AlpacaGrammarToolWindowFactory.kt
@@ -1,5 +1,6 @@
 package com.halotukozak.alpaca.plugin.toolwindow
 
+import com.halotukozak.alpaca.plugin.grammar.ResolvedGrammar
 import com.halotukozak.alpaca.plugin.grammar.resolveGrammarForFile
 import com.halotukozak.alpaca.plugin.icons.AlpacaIcons
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -19,6 +20,8 @@ import java.awt.BorderLayout
 import javax.swing.JPanel
 import javax.swing.JTree
 import javax.swing.SwingConstants
+import javax.swing.event.TreeExpansionEvent
+import javax.swing.event.TreeWillExpandListener
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeModel
 
@@ -26,7 +29,10 @@ import javax.swing.tree.DefaultTreeModel
  * "Alpaca Grammar": the whole of the current file's grammar (every token, every production
  * alternative), browsable in one place -- unlike Structure View (this file's own parse tree) or
  * Quick Documentation (one node's rule at a time). Refreshes on every editor selection change to
- * always show the grammar of whichever file is now on top.
+ * always show the grammar of whichever file is now on top. A nonterminal referenced inside a
+ * production's right-hand side is itself expandable: clicking it lazily reveals that nonterminal's
+ * own alternatives (see [GrammarTreeNode.expandable]), so exploring a recursive grammar (`Expr ->
+ * Expr '+' Expr`) only ever grows as deep as actually clicked.
  */
 class AlpacaGrammarToolWindowFactory : ToolWindowFactory {
     override fun createToolWindowContent(
@@ -49,14 +55,26 @@ class AlpacaGrammarToolWindowFactory : ToolWindowFactory {
     }
 }
 
+/** Marks a Swing tree node added purely so an unexpanded [GrammarTreeNode.expandable] node shows
+ *  an expand arrow; swapped out for the real alternatives the moment it's actually expanded. */
+private object LoadingPlaceholder
+
 private class GrammarPanel(
     private val project: Project,
 ) : JPanel(BorderLayout()) {
     private val placeholder = JBLabel("Open an Alpaca-defined file to see its grammar.", SwingConstants.CENTER)
+    private var resolved: ResolvedGrammar? = null
     private val tree =
         Tree().apply {
             isRootVisible = true
             cellRenderer = GrammarTreeCellRenderer()
+            addTreeWillExpandListener(
+                object : TreeWillExpandListener {
+                    override fun treeWillExpand(event: TreeExpansionEvent) = expandLazily(event)
+
+                    override fun treeWillCollapse(event: TreeExpansionEvent) = Unit
+                },
+            )
         }
 
     init {
@@ -64,12 +82,13 @@ private class GrammarPanel(
     }
 
     fun showGrammarFor(file: VirtualFile?) {
-        val resolved = file?.let { resolveGrammarForFile(project, it) }
+        resolved = file?.let { resolveGrammarForFile(project, it) }
         removeAll()
-        if (resolved == null) {
+        val currentResolved = resolved
+        if (currentResolved == null) {
             add(placeholder, BorderLayout.CENTER)
         } else {
-            tree.model = DefaultTreeModel(toSwingTree(buildGrammarTree(resolved)))
+            tree.model = DefaultTreeModel(toSwingTree(buildGrammarTree(currentResolved)))
             // Only the root: a grammar with hundreds of productions (e.g. the Scala one this
             // project's own parser targets) would otherwise dump every alternative open at once.
             tree.expandRow(0)
@@ -79,9 +98,28 @@ private class GrammarPanel(
         repaint()
     }
 
+    private fun expandLazily(event: TreeExpansionEvent) {
+        val treeNode = event.path.lastPathComponent as? DefaultMutableTreeNode ?: return
+        val grammarNode = treeNode.userObject as? GrammarTreeNode ?: return
+        if (!grammarNode.expandable) return
+        val onlyChild = treeNode.firstChild as? DefaultMutableTreeNode ?: return
+        if (onlyChild.userObject !== LoadingPlaceholder) return
+
+        val currentResolved = resolved ?: return
+        treeNode.removeAllChildren()
+        for (alternative in alternativesOf(grammarNode.primaryText, currentResolved)) {
+            treeNode.add(toSwingTree(alternative))
+        }
+        (tree.model as DefaultTreeModel).nodeStructureChanged(treeNode)
+    }
+
     private fun toSwingTree(node: GrammarTreeNode): DefaultMutableTreeNode =
         DefaultMutableTreeNode(node).apply {
-            for (child in node.children) add(toSwingTree(child))
+            if (node.expandable && node.children.isEmpty()) {
+                add(DefaultMutableTreeNode(LoadingPlaceholder))
+            } else {
+                for (child in node.children) add(toSwingTree(child))
+            }
         }
 }
 

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/AlpacaGrammarToolWindowFactory.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/AlpacaGrammarToolWindowFactory.kt
@@ -1,0 +1,108 @@
+package com.halotukozak.alpaca.plugin.toolwindow
+
+import com.halotukozak.alpaca.plugin.grammar.resolveGrammarForFile
+import com.halotukozak.alpaca.plugin.icons.AlpacaIcons
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.ColoredTreeCellRenderer
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.content.ContentFactory
+import com.intellij.ui.treeStructure.Tree
+import java.awt.BorderLayout
+import javax.swing.JPanel
+import javax.swing.JTree
+import javax.swing.SwingConstants
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.DefaultTreeModel
+
+/**
+ * "Alpaca Grammar": the whole of the current file's grammar (every token, every production
+ * alternative), browsable in one place -- unlike Structure View (this file's own parse tree) or
+ * Quick Documentation (one node's rule at a time). Refreshes on every editor selection change to
+ * always show the grammar of whichever file is now on top.
+ */
+class AlpacaGrammarToolWindowFactory : ToolWindowFactory {
+    override fun createToolWindowContent(
+        project: Project,
+        toolWindow: ToolWindow,
+    ) {
+        val panel = GrammarPanel(project)
+        val content = ContentFactory.getInstance().createContent(panel, null, false)
+        toolWindow.contentManager.addContent(content)
+
+        project.messageBus.connect(toolWindow.disposable).subscribe(
+            FileEditorManagerListener.FILE_EDITOR_MANAGER,
+            object : FileEditorManagerListener {
+                override fun selectionChanged(event: FileEditorManagerEvent) {
+                    panel.showGrammarFor(event.newFile)
+                }
+            },
+        )
+        panel.showGrammarFor(FileEditorManager.getInstance(project).selectedFiles.firstOrNull())
+    }
+}
+
+private class GrammarPanel(
+    private val project: Project,
+) : JPanel(BorderLayout()) {
+    private val placeholder = JBLabel("Open an Alpaca-defined file to see its grammar.", SwingConstants.CENTER)
+    private val tree =
+        Tree().apply {
+            isRootVisible = true
+            cellRenderer = GrammarTreeCellRenderer()
+        }
+
+    init {
+        add(placeholder, BorderLayout.CENTER)
+    }
+
+    fun showGrammarFor(file: VirtualFile?) {
+        val resolved = file?.let { resolveGrammarForFile(project, it) }
+        removeAll()
+        if (resolved == null) {
+            add(placeholder, BorderLayout.CENTER)
+        } else {
+            tree.model = DefaultTreeModel(toSwingTree(buildGrammarTree(resolved)))
+            // Only the root: a grammar with hundreds of productions (e.g. the Scala one this
+            // project's own parser targets) would otherwise dump every alternative open at once.
+            tree.expandRow(0)
+            add(JBScrollPane(tree), BorderLayout.CENTER)
+        }
+        revalidate()
+        repaint()
+    }
+
+    private fun toSwingTree(node: GrammarTreeNode): DefaultMutableTreeNode =
+        DefaultMutableTreeNode(node).apply {
+            for (child in node.children) add(toSwingTree(child))
+        }
+}
+
+/** Renders a [GrammarTreeNode]: bold for a category/nonterminal heading, the pattern or
+ *  right-hand side dimmed as a secondary segment -- the same role Structure View's location
+ *  string plays -- instead of one flat string. */
+private class GrammarTreeCellRenderer : ColoredTreeCellRenderer() {
+    override fun customizeCellRenderer(
+        tree: JTree,
+        value: Any?,
+        selected: Boolean,
+        expanded: Boolean,
+        leaf: Boolean,
+        row: Int,
+        hasFocus: Boolean,
+    ) {
+        val node = (value as? DefaultMutableTreeNode)?.userObject as? GrammarTreeNode ?: return
+        icon = AlpacaIcons.FILE
+        append(node.primaryText, if (node.bold) SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES else SimpleTextAttributes.REGULAR_ATTRIBUTES)
+        node.secondaryText?.let {
+            append("  $it", SimpleTextAttributes.GRAYED_ATTRIBUTES)
+        }
+    }
+}

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeNode.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeNode.kt
@@ -11,11 +11,19 @@ import com.halotukozak.alpaca.plugin.grammar.symbolLabel
  * to be rendered dimmed/secondary (a token's pattern, a production's right-hand side) -- the same
  * role Structure View's location string plays, kept out of [primaryText] so a renderer can tell
  * the two apart instead of parsing one flat string.
+ *
+ * [expandable] marks a nonterminal reference inside a production's right-hand side: [children] is
+ * empty even though the node genuinely has some, because computing them means recursing into that
+ * nonterminal's own alternatives, and a grammar is routinely self-referential (`Expr -> Expr '+'
+ * Expr`) -- eagerly unrolling every reachable nonterminal would never terminate. A UI is expected
+ * to call [alternativesOf] itself, lazily, the moment such a node is actually expanded; that keeps
+ * the tree only ever as deep as a user actually clicked, never deeper.
  */
 data class GrammarTreeNode(
     val primaryText: String,
     val secondaryText: String? = null,
     val bold: Boolean = false,
+    val expandable: Boolean = false,
     val children: List<GrammarTreeNode> = emptyList(),
 )
 
@@ -44,7 +52,7 @@ fun buildGrammarTree(resolved: ResolvedGrammar): GrammarTreeNode {
                     GrammarTreeNode(
                         lhs,
                         bold = true,
-                        children = alternatives.map { alternativeNode(it, resolved.tokens) },
+                        children = alternatives.map { alternativeRow(it, resolved.tokens) },
                     )
                 }
         children += GrammarTreeNode("Productions (${nonterminals.size})", bold = true, children = nonterminals)
@@ -53,15 +61,32 @@ fun buildGrammarTree(resolved: ResolvedGrammar): GrammarTreeNode {
     return GrammarTreeNode(resolved.lexerId, bold = true, children = children)
 }
 
+/**
+ * [nonterminal]'s own alternatives, as rows -- the same shape [buildGrammarTree] already builds
+ * for every nonterminal up front, computed for just this one on demand. This is what a UI calls
+ * when the user expands a nonterminal-reference node it couldn't afford to expand eagerly.
+ */
+fun alternativesOf(
+    nonterminal: String,
+    resolved: ResolvedGrammar,
+): List<GrammarTreeNode> {
+    val grammar = resolved.parserGrammar ?: return emptyList()
+    return grammar.productions.filter { it.lhs == nonterminal }.map { alternativeRow(it, resolved.tokens) }
+}
+
 private fun tokenNode(token: TokenSpec): GrammarTreeNode {
     val secondary = if (token.ignored) "${token.pattern}  [ignored]" else token.pattern
     return GrammarTreeNode(token.name, secondary)
 }
 
-private fun alternativeNode(
+private fun alternativeRow(
     production: ProductionSpec,
     tokens: List<TokenSpec>,
 ): GrammarTreeNode {
-    val rhs = if (production.rhs.isEmpty()) "ε" else production.rhs.joinToString(" ") { symbolLabel(it, tokens) }
-    return GrammarTreeNode(production.name ?: "(unnamed)", rhs)
+    val rhsText = if (production.rhs.isEmpty()) "ε" else production.rhs.joinToString(" ") { symbolLabel(it, tokens) }
+    val nonterminalRefs =
+        production.rhs
+            .filter { it.kind != "terminal" }
+            .map { GrammarTreeNode(it.name, bold = true, expandable = true) }
+    return GrammarTreeNode(production.name ?: "(unnamed)", rhsText, children = nonterminalRefs)
 }

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeNode.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeNode.kt
@@ -1,0 +1,67 @@
+package com.halotukozak.alpaca.plugin.toolwindow
+
+import com.halotukozak.alpaca.plugin.grammar.ProductionSpec
+import com.halotukozak.alpaca.plugin.grammar.ResolvedGrammar
+import com.halotukozak.alpaca.plugin.grammar.TokenSpec
+import com.halotukozak.alpaca.plugin.grammar.symbolLabel
+
+/**
+ * One row in the grammar tool window, independent of any UI toolkit -- easy to build and test
+ * without a Swing component or a platform test fixture. [secondaryText], when present, is meant
+ * to be rendered dimmed/secondary (a token's pattern, a production's right-hand side) -- the same
+ * role Structure View's location string plays, kept out of [primaryText] so a renderer can tell
+ * the two apart instead of parsing one flat string.
+ */
+data class GrammarTreeNode(
+    val primaryText: String,
+    val secondaryText: String? = null,
+    val bold: Boolean = false,
+    val children: List<GrammarTreeNode> = emptyList(),
+)
+
+/**
+ * The whole of [resolved]'s grammar as a browsable tree: every lexer token (name, pattern, and
+ * whether it's `ignored`), then every parser production grouped by its nonterminal, each
+ * alternative labelled the same way Quick Documentation labels it (see [symbolLabel]) -- but for
+ * the grammar as a whole, not one node at a time. No parser grammar (lexer-only association)
+ * omits the productions branch entirely rather than showing it empty.
+ */
+fun buildGrammarTree(resolved: ResolvedGrammar): GrammarTreeNode {
+    val children =
+        mutableListOf(
+            GrammarTreeNode(
+                "Tokens (${resolved.tokens.size})",
+                bold = true,
+                children = resolved.tokens.map { tokenNode(it) },
+            ),
+        )
+
+    resolved.parserGrammar?.let { grammar ->
+        val nonterminals =
+            grammar.productions
+                .groupBy { it.lhs }
+                .map { (lhs, alternatives) ->
+                    GrammarTreeNode(
+                        lhs,
+                        bold = true,
+                        children = alternatives.map { alternativeNode(it, resolved.tokens) },
+                    )
+                }
+        children += GrammarTreeNode("Productions (${nonterminals.size})", bold = true, children = nonterminals)
+    }
+
+    return GrammarTreeNode(resolved.lexerId, bold = true, children = children)
+}
+
+private fun tokenNode(token: TokenSpec): GrammarTreeNode {
+    val secondary = if (token.ignored) "${token.pattern}  [ignored]" else token.pattern
+    return GrammarTreeNode(token.name, secondary)
+}
+
+private fun alternativeNode(
+    production: ProductionSpec,
+    tokens: List<TokenSpec>,
+): GrammarTreeNode {
+    val rhs = if (production.rhs.isEmpty()) "ε" else production.rhs.joinToString(" ") { symbolLabel(it, tokens) }
+    return GrammarTreeNode(production.name ?: "(unnamed)", rhs)
+}

--- a/ij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ij-plugin/src/main/resources/META-INF/plugin.xml
@@ -28,6 +28,8 @@
       <li><b>Quick Documentation</b> (hover / Ctrl+Q) showing a token's pattern or a nonterminal's
         full set of production alternatives.</li>
       <li><b>Pair-quote insertion</b> for grammars whose strings are delimited by <code>"</code> or <code>'</code>.</li>
+      <li>An <b>Alpaca Grammar</b> tool window browsing the current file's whole grammar --
+        every token and every production alternative -- in one place.</li>
     </ul>
     <p>
       Point <b>Settings | Tools | Alpaca</b> at your grammar export directory and map file extensions
@@ -79,6 +81,10 @@
         language="Alpaca"
         implementationClass="com.halotukozak.alpaca.plugin.formatting.AlpacaFormattingModelBuilder"/>
     <notificationGroup id="Alpaca" displayType="BALLOON"/>
+    <toolWindow
+        id="Alpaca Grammar"
+        anchor="right"
+        factoryClass="com.halotukozak.alpaca.plugin.toolwindow.AlpacaGrammarToolWindowFactory"/>
   </extensions>
 
   <projectListeners>

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeTest.kt
@@ -1,0 +1,76 @@
+package com.halotukozak.alpaca.plugin.toolwindow
+
+import com.halotukozak.alpaca.plugin.grammar.ParserGrammar
+import com.halotukozak.alpaca.plugin.grammar.ProductionSpec
+import com.halotukozak.alpaca.plugin.grammar.ResolvedGrammar
+import com.halotukozak.alpaca.plugin.grammar.SymbolSpec
+import com.halotukozak.alpaca.plugin.grammar.TokenSpec
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** [buildGrammarTree] is plain data in, plain data out -- no PSI, no platform fixture needed. */
+class GrammarTreeTest {
+    private val plusToken = TokenSpec(name = "\\+", pattern = "\\+", ignored = false)
+    private val intToken = TokenSpec(name = "int", pattern = "\\d+", ignored = false)
+    private val whitespaceToken = TokenSpec(name = "ws", pattern = "[ \\t]+", ignored = true)
+
+    @Test
+    fun `lists every token, marking ignored ones`() {
+        val resolved = ResolvedGrammar("Lexer", listOf(intToken, whitespaceToken), parserGrammar = null)
+
+        val tokens = buildGrammarTree(resolved).children.single()
+
+        assertEquals("Tokens (2)" to true, tokens.primaryText to tokens.bold)
+        assertEquals(
+            listOf("int" to "\\d+", "ws" to "[ \\t]+  [ignored]"),
+            tokens.children.map { it.primaryText to it.secondaryText },
+        )
+    }
+
+    @Test
+    fun `omits the productions branch entirely when there is no parser grammar`() {
+        val resolved = ResolvedGrammar("Lexer", listOf(intToken), parserGrammar = null)
+
+        assertEquals(listOf("Tokens (1)"), buildGrammarTree(resolved).children.map { it.primaryText })
+    }
+
+    @Test
+    fun `groups productions by nonterminal and labels each alternative`() {
+        val plus =
+            ProductionSpec(
+                "Expr",
+                listOf(SymbolSpec("nonterminal", "Expr"), SymbolSpec("terminal", "\\+"), SymbolSpec("nonterminal", "Expr")),
+                "plus",
+            )
+        val literal = ProductionSpec("Expr", listOf(SymbolSpec("terminal", "int")), name = null)
+        val grammar = ParserGrammar("Parser", listOf(plus, literal))
+        val resolved = ResolvedGrammar("Lexer", listOf(plusToken, intToken), grammar)
+
+        val productions = buildGrammarTree(resolved).children[1]
+
+        assertEquals("Productions (1)", productions.primaryText)
+        val expr = productions.children.single()
+        assertEquals("Expr" to true, expr.primaryText to expr.bold)
+        assertEquals(
+            listOf("plus" to "Expr '+' Expr", "(unnamed)" to "int"),
+            expr.children.map { it.primaryText to it.secondaryText },
+        )
+    }
+
+    @Test
+    fun `labels an epsilon production`() {
+        val epsilon = ProductionSpec("Opt", emptyList(), name = null)
+        val grammar = ParserGrammar("Parser", listOf(epsilon))
+        val resolved = ResolvedGrammar("Lexer", emptyList(), grammar)
+
+        val alternative =
+            buildGrammarTree(resolved)
+                .children[1]
+                .children
+                .single()
+                .children
+                .single()
+
+        assertEquals("(unnamed)" to "ε", alternative.primaryText to alternative.secondaryText)
+    }
+}

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeTest.kt
@@ -6,13 +6,25 @@ import com.halotukozak.alpaca.plugin.grammar.ResolvedGrammar
 import com.halotukozak.alpaca.plugin.grammar.SymbolSpec
 import com.halotukozak.alpaca.plugin.grammar.TokenSpec
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-/** [buildGrammarTree] is plain data in, plain data out -- no PSI, no platform fixture needed. */
+/** [buildGrammarTree]/[alternativesOf] are plain data in, plain data out -- no PSI, no platform
+ *  test fixture needed. */
 class GrammarTreeTest {
     private val plusToken = TokenSpec(name = "\\+", pattern = "\\+", ignored = false)
     private val intToken = TokenSpec(name = "int", pattern = "\\d+", ignored = false)
     private val whitespaceToken = TokenSpec(name = "ws", pattern = "[ \\t]+", ignored = true)
+
+    /** `Expr -> Expr '+' Expr` (named `plus`) and `Expr -> int` (unnamed): the shape MathParser's
+     *  own grammar has, minimally reproduced so a test doesn't depend on the real export fixture. */
+    private val plusProduction =
+        ProductionSpec(
+            "Expr",
+            listOf(SymbolSpec("nonterminal", "Expr"), SymbolSpec("terminal", "\\+"), SymbolSpec("nonterminal", "Expr")),
+            "plus",
+        )
+    private val literalProduction = ProductionSpec("Expr", listOf(SymbolSpec("terminal", "int")), name = null)
 
     @Test
     fun `lists every token, marking ignored ones`() {
@@ -36,14 +48,7 @@ class GrammarTreeTest {
 
     @Test
     fun `groups productions by nonterminal and labels each alternative`() {
-        val plus =
-            ProductionSpec(
-                "Expr",
-                listOf(SymbolSpec("nonterminal", "Expr"), SymbolSpec("terminal", "\\+"), SymbolSpec("nonterminal", "Expr")),
-                "plus",
-            )
-        val literal = ProductionSpec("Expr", listOf(SymbolSpec("terminal", "int")), name = null)
-        val grammar = ParserGrammar("Parser", listOf(plus, literal))
+        val grammar = ParserGrammar("Parser", listOf(plusProduction, literalProduction))
         val resolved = ResolvedGrammar("Lexer", listOf(plusToken, intToken), grammar)
 
         val productions = buildGrammarTree(resolved).children[1]
@@ -55,6 +60,52 @@ class GrammarTreeTest {
             listOf("plus" to "Expr '+' Expr", "(unnamed)" to "int"),
             expr.children.map { it.primaryText to it.secondaryText },
         )
+    }
+
+    @Test
+    fun `a named alternative's nonterminal references are expandable, its terminals are not`() {
+        val grammar = ParserGrammar("Parser", listOf(plusProduction, literalProduction))
+        val resolved = ResolvedGrammar("Lexer", listOf(plusToken, intToken), grammar)
+
+        val alternatives =
+            buildGrammarTree(resolved)
+                .children[1]
+                .children
+                .single()
+                .children
+        val plusAlternative = alternatives.first { it.primaryText == "plus" }
+        val literalAlternative = alternatives.first { it.primaryText == "(unnamed)" }
+
+        // Expr -> Expr '+' Expr: both Expr occurrences become their own expandable child (not
+        // merged into one), the '+' terminal contributes nothing.
+        assertEquals(listOf("Expr", "Expr"), plusAlternative.children.map { it.primaryText })
+        assertTrue(plusAlternative.children.all { it.expandable })
+        assertEquals(emptyList<GrammarTreeNode>(), literalAlternative.children)
+    }
+
+    @Test
+    fun `alternativesOf computes the same rows for one nonterminal on demand`() {
+        val grammar = ParserGrammar("Parser", listOf(plusProduction, literalProduction))
+        val resolved = ResolvedGrammar("Lexer", listOf(plusToken, intToken), grammar)
+
+        val eager =
+            buildGrammarTree(resolved)
+                .children[1]
+                .children
+                .single()
+                .children
+        val lazy = alternativesOf("Expr", resolved)
+
+        assertEquals(eager, lazy)
+    }
+
+    @Test
+    fun `alternativesOf is empty for an unknown nonterminal or no parser grammar`() {
+        val withParser = ResolvedGrammar("Lexer", listOf(intToken), ParserGrammar("Parser", listOf(literalProduction)))
+        val withoutParser = ResolvedGrammar("Lexer", listOf(intToken), parserGrammar = null)
+
+        assertEquals(emptyList<GrammarTreeNode>(), alternativesOf("NoSuchRule", withParser))
+        assertEquals(emptyList<GrammarTreeNode>(), alternativesOf("Expr", withoutParser))
     }
 
     @Test


### PR DESCRIPTION
## Summary

The "Grammar / parse-trace" tool window named as a differentiator in the plugin's research report. Structure View shows this file's own parse tree; Quick Documentation shows one node's rule at a time. Neither lets you see a grammar's full token/production set in one place — this does.

- New **"Alpaca Grammar"** tool window (anchored right), refreshing on every editor selection change to always show the grammar of whichever file is on top.
- Tree: `Tokens (N)` (name, pattern, `[ignored]` flag) and `Productions (N)` grouped by nonterminal, each alternative labelled the same way Quick Documentation labels it — `plus: Expr '+' Expr`, `(unnamed): int` — but for the whole grammar, not one node at a time.
- `buildGrammarTree(resolved: ResolvedGrammar): GrammarTreeNode` is pure data in/out, no UI dependency, directly unit-tested (`GrammarTreeTest`); a thin `ColoredTreeCellRenderer` (icon, bold category rows, dimmed pattern/right-hand-side text) turns it into a `Tree`.
- Extracted `symbolLabel` out of `AlpacaDocumentationProvider` into a shared `grammar/SymbolLabel.kt`, since both surfaces spell out a production's right-hand side identically.
- No custom tool-window stripe icon: the plugin's only icon (`icons/alpaca.svg`) is a detailed, colorful file-type icon, not the simple monochrome 13×13 glyph a stripe icon needs — using it there looked wrong, so this leaves the platform's default icon rather than force a mismatch.

## Test plan

- [x] `GrammarTreeTest` — plain-JUnit coverage of the tree-building logic (token listing incl. ignored, production grouping, unnamed/epsilon alternatives, no-parser-grammar case)
- [x] full `./gradlew ktlintCheck test` green
- [x] verified live in the sandbox — user confirmed the rendering looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)