### PR TITLE
fix(internal): expose withDefault/Empty givens beyond package alpaca

### DIFF
--- a/src/halotukozak/alpaca/internal/Empty.scala
+++ b/src/halotukozak/alpaca/internal/Empty.scala
@@ -17,9 +17,9 @@ import halotukozak.made.label
  * @tparam T the type to create empty instances of
  */
 @implicitNotFound("${T} should be a case class.")
-private[alpaca] trait Empty[T] extends (() => T)
+trait Empty[T] extends (() => T)
 
-private[alpaca] object Empty:
+object Empty:
   inline private def collectDefaults(elems: Tuple)(using elems.type containsOnly MadeFieldElem): Tuple =
     inline elems match
       case EmptyTuple => EmptyTuple

--- a/src/halotukozak/alpaca/internal/WithDefault.scala
+++ b/src/halotukozak/alpaca/internal/WithDefault.scala
@@ -12,9 +12,9 @@ package internal
  * @tparam Q the default type
  */
 //todo: better name
-infix private[alpaca] class withDefault[T, Q]
+infix class withDefault[T, Q]
 
-private[alpaca] trait withDefaultLowImplicitPriority:
+trait withDefaultLowImplicitPriority:
 
   /**
    * Ignore default - use the provided type when explicitly specified.
@@ -24,7 +24,7 @@ private[alpaca] trait withDefaultLowImplicitPriority:
    */
   inline given useProvided[Provided, Default]: (Provided withDefault Default) = new (Provided withDefault Default)
 
-private[alpaca] object withDefault extends withDefaultLowImplicitPriority:
+object withDefault extends withDefaultLowImplicitPriority:
 
   /**
    * Infer type argument to default when no type is explicitly provided.


### PR DESCRIPTION
## Summary
- `withDefault` (`WithDefault.scala`) and `Empty` (`Empty.scala`) were `private[alpaca]`, but `lexer.scala`'s public `lexer`/`parser` macros expose `using Ctx withDefault Default` and `empty: Empty[Ctx]` context parameters. Any external caller of this DSL is necessarily outside package `halotukozak.alpaca`, so implicit search needs to find `withDefault.useDefault`/`Empty.derived` from there too.
- This only "worked" because Scala's implicit search doesn't check accessibility today — exactly the leniency planned for removal in Scala 3.10. Once removed, these would silently stop resolving for every real external consumer of the library, not just for the `bench.alpaca` benchmarks module that happened to surface it.
- Fix: drop `private[alpaca]` from both. No relocation of the benchmark files needed — the four files #470 named (`BigGrammar.scala`, `DeepNestedParser.scala`, `FlatListParser.scala`, `JsonParser.scala`) stay in `bench.alpaca` unchanged and now compile warning-free, because the actual root cause (visibility) is fixed rather than worked around by moving call sites to a package nested under `halotukozak.alpaca`.

## Test plan
- [x] `CI=true ./mill __.compile` (clean, full build: jvm/js/native + both benchmark modules) — the `not accessible`/`In Scala 3.10 this implicit will no longer be found` warnings are gone everywhere, not just in the four files #470 named
- [x] `CI=true ./mill jvm.test` — 188/188 passing
- [x] `./mill js.compile`, `./mill native.compile` — clean
- [x] `./mill benchmarks.alpaca.compile` — clean (only pre-existing, unrelated deprecation warnings remain)

Fixes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EDQ1CRq6YEwadRSQxbZ1j