### PR TITLE
Add "go to source" navigation to the Alpaca Grammar tree

### DIFF
--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/GrammarFile.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/GrammarFile.kt
@@ -65,6 +65,8 @@ data class TokenSpec(
     val name: String,
     val pattern: String,
     val ignored: Boolean,
+    val sourceFile: String? = null,
+    val sourceLine: Int? = null,
 )
 
 /** Reads a `<lexer>.tokens.json` file written by Alpaca's compile-time grammar export. */
@@ -97,6 +99,8 @@ data class ProductionSpec(
     val lhs: String,
     val rhs: List<SymbolSpec>,
     val name: String?,
+    val sourceFile: String? = null,
+    val sourceLine: Int? = null,
 )
 
 /** Reads a `<parser>.productions.json` file written by Alpaca's compile-time grammar export. */

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/AlpacaGrammarToolWindowFactory.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/AlpacaGrammarToolWindowFactory.kt
@@ -6,7 +6,9 @@ import com.halotukozak.alpaca.plugin.icons.AlpacaIcons
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
@@ -17,6 +19,10 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.content.ContentFactory
 import com.intellij.ui.treeStructure.Tree
 import java.awt.BorderLayout
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import javax.swing.JPanel
 import javax.swing.JTree
 import javax.swing.SwingConstants
@@ -32,7 +38,9 @@ import javax.swing.tree.DefaultTreeModel
  * always show the grammar of whichever file is now on top. A nonterminal referenced inside a
  * production's right-hand side is itself expandable: clicking it lazily reveals that nonterminal's
  * own alternatives (see [GrammarTreeNode.expandable]), so exploring a recursive grammar (`Expr ->
- * Expr '+' Expr`) only ever grows as deep as actually clicked.
+ * Expr '+' Expr`) only ever grows as deep as actually clicked. Double-clicking (or pressing Enter
+ * on) a token or production row jumps to the `lexer{...}`/`parser` rule that defines it, when the
+ * export recorded one (see [GrammarTreeNode.sourceFile]).
  */
 class AlpacaGrammarToolWindowFactory : ToolWindowFactory {
     override fun createToolWindowContent(
@@ -75,6 +83,25 @@ private class GrammarPanel(
                     override fun treeWillCollapse(event: TreeExpansionEvent) = Unit
                 },
             )
+            addMouseListener(
+                object : MouseAdapter() {
+                    override fun mouseClicked(e: MouseEvent) {
+                        if (e.clickCount != 2) return
+                        val jtree = e.source as? JTree ?: return
+                        val path = jtree.getPathForLocation(e.x, e.y) ?: return
+                        navigateToSource(path.lastPathComponent as? DefaultMutableTreeNode)
+                    }
+                },
+            )
+            addKeyListener(
+                object : KeyAdapter() {
+                    override fun keyPressed(e: KeyEvent) {
+                        if (e.keyCode != KeyEvent.VK_ENTER) return
+                        val jtree = e.source as? JTree ?: return
+                        navigateToSource(jtree.selectionPath?.lastPathComponent as? DefaultMutableTreeNode)
+                    }
+                },
+            )
         }
 
     init {
@@ -111,6 +138,19 @@ private class GrammarPanel(
             treeNode.add(toSwingTree(alternative))
         }
         (tree.model as DefaultTreeModel).nodeStructureChanged(treeNode)
+    }
+
+    /** Opens the `lexer{...}`/`parser` rule [treeNode] was defined by, if the export recorded a
+     *  source location for it (see [GrammarTreeNode.sourceFile]) and the file can still be found --
+     *  a no-op otherwise, since the recorded path is an absolute compile-time path that may no
+     *  longer exist (a different machine, a moved/renamed source file). */
+    private fun navigateToSource(treeNode: DefaultMutableTreeNode?) {
+        val node = treeNode?.userObject as? GrammarTreeNode ?: return
+        val sourceFile = node.sourceFile ?: return
+        val sourceLine = node.sourceLine ?: return
+        val fileSystem = LocalFileSystem.getInstance()
+        val virtualFile = fileSystem.findFileByPath(sourceFile) ?: fileSystem.refreshAndFindFileByPath(sourceFile) ?: return
+        OpenFileDescriptor(project, virtualFile, sourceLine, 0).navigate(true)
     }
 
     private fun toSwingTree(node: GrammarTreeNode): DefaultMutableTreeNode =

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeNode.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeNode.kt
@@ -18,6 +18,11 @@ import com.halotukozak.alpaca.plugin.grammar.symbolLabel
  * Expr`) -- eagerly unrolling every reachable nonterminal would never terminate. A UI is expected
  * to call [alternativesOf] itself, lazily, the moment such a node is actually expanded; that keeps
  * the tree only ever as deep as a user actually clicked, never deeper.
+ *
+ * [sourceFile]/[sourceLine] locate the lexer/parser rule this row was defined by, letting a UI
+ * offer "go to source"; null for a row with no source of its own -- a category heading (the
+ * "Tokens"/"Productions" groups, a nonterminal's own heading) or a production synthesized from
+ * EBNF sugar (`List`/`Option`/`SeparatedBy`) rather than written directly in the grammar.
  */
 data class GrammarTreeNode(
     val primaryText: String,
@@ -25,6 +30,8 @@ data class GrammarTreeNode(
     val bold: Boolean = false,
     val expandable: Boolean = false,
     val children: List<GrammarTreeNode> = emptyList(),
+    val sourceFile: String? = null,
+    val sourceLine: Int? = null,
 )
 
 /**
@@ -76,7 +83,7 @@ fun alternativesOf(
 
 private fun tokenNode(token: TokenSpec): GrammarTreeNode {
     val secondary = if (token.ignored) "${token.pattern}  [ignored]" else token.pattern
-    return GrammarTreeNode(token.name, secondary)
+    return GrammarTreeNode(token.name, secondary, sourceFile = token.sourceFile.orNullSource(), sourceLine = token.sourceLine)
 }
 
 private fun alternativeRow(
@@ -88,5 +95,15 @@ private fun alternativeRow(
         production.rhs
             .filter { it.kind != "terminal" }
             .map { GrammarTreeNode(it.name, bold = true, expandable = true) }
-    return GrammarTreeNode(production.name ?: "(unnamed)", rhsText, children = nonterminalRefs)
+    return GrammarTreeNode(
+        production.name ?: "(unnamed)",
+        rhsText,
+        children = nonterminalRefs,
+        sourceFile = production.sourceFile.orNullSource(),
+        sourceLine = production.sourceLine,
+    )
 }
+
+/** A blank export-side `sourceFile` marks a row with no source of its own (see [GrammarTreeNode]'s
+ *  doc) -- normalized to `null` here so a UI can tell "no source" apart from "source is /path". */
+private fun String?.orNullSource(): String? = this?.takeIf { it.isNotBlank() }

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeTest.kt
@@ -124,4 +124,38 @@ class GrammarTreeTest {
 
         assertEquals("(unnamed)" to "ε", alternative.primaryText to alternative.secondaryText)
     }
+
+    @Test
+    fun `carries the source location for tokens and production alternatives`() {
+        val token = intToken.copy(sourceFile = "/x/Lexer.scala", sourceLine = 4)
+        val production = literalProduction.copy(sourceFile = "/x/Parser.scala", sourceLine = 9)
+        val resolved = ResolvedGrammar("Lexer", listOf(token), ParserGrammar("Parser", listOf(production)))
+
+        val tokenNode = buildGrammarTree(resolved).children[0].children.single()
+        assertEquals("/x/Lexer.scala" to 4, tokenNode.sourceFile to tokenNode.sourceLine)
+
+        val productionNode =
+            buildGrammarTree(resolved)
+                .children[1]
+                .children
+                .single()
+                .children
+                .single()
+        assertEquals("/x/Parser.scala" to 9, productionNode.sourceFile to productionNode.sourceLine)
+    }
+
+    @Test
+    fun `a blank exported source file means no source, not an empty path`() {
+        val synthetic = literalProduction.copy(sourceFile = "", sourceLine = 0)
+        val resolved = ResolvedGrammar("Lexer", emptyList(), ParserGrammar("Parser", listOf(synthetic)))
+
+        val node =
+            buildGrammarTree(resolved)
+                .children[1]
+                .children
+                .single()
+                .children
+                .single()
+        assertEquals(null, node.sourceFile)
+    }
 }


### PR DESCRIPTION
## Summary
- Double-clicking (or pressing Enter on) a token or production row in the Alpaca Grammar tool window jumps to the `lexer{...}`/`parser` rule that defines it, in the Scala source.
- Consumes the `sourceFile`/`sourceLine` fields the alpaca library's grammar export now records per token/production (halotukozak-com/alpaca#<export-rule-source-positions PR>).
- A row with no source of its own (a category heading, or a production synthesized from EBNF sugar) has no navigation target and is left alone.

Stacked on #580 (Alpaca Grammar tool window) since it extends that tree.

## Test plan
- [x] `./gradlew ktlintCheck test` passes
- [x] New unit tests for source-location propagation and the blank-source-means-no-source case
- [x] Verified live in the sandbox IDE: double-clicking a production/token row opens the correct Scala file at the correct line

🤖 Generated with [Claude Code](https://claude.com/claude-code)