### PR TITLE
fix(ij-plugin): decode the grammar export's nested source object

### DIFF
--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/GrammarFile.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/grammar/GrammarFile.kt
@@ -54,6 +54,16 @@ private inline fun <reified T> readVersioned(text: String): VersionedExport<T> {
     return VersionedExport.Compatible(Json.decodeFromString<ExportEnvelope<T>>(text).context)
 }
 
+/** The location of a lexer/parser rule as written in the grammar's own source, exported nested
+ *  under a `"source"` key (see `Source` in the alpaca library); absent/`null` for a rule with no
+ *  source of its own -- a production synthesized from EBNF sugar (`List`/`Option`/`SeparatedBy`)
+ *  rather than written directly in the grammar. */
+@Serializable
+data class SourceLocation(
+    val line: Int,
+    val file: String,
+)
+
 /**
  * One token rule as exported by Alpaca's `lexer{...}` macro (see
  * `ALPACA_GRAMMAR_EXPORT_DIR` in the alpaca library): a name, the regex
@@ -65,8 +75,7 @@ data class TokenSpec(
     val name: String,
     val pattern: String,
     val ignored: Boolean,
-    val sourceFile: String? = null,
-    val sourceLine: Int? = null,
+    val source: SourceLocation? = null,
 )
 
 /** Reads a `<lexer>.tokens.json` file written by Alpaca's compile-time grammar export. */
@@ -99,8 +108,7 @@ data class ProductionSpec(
     val lhs: String,
     val rhs: List<SymbolSpec>,
     val name: String?,
-    val sourceFile: String? = null,
-    val sourceLine: Int? = null,
+    val source: SourceLocation? = null,
 )
 
 /** Reads a `<parser>.productions.json` file written by Alpaca's compile-time grammar export. */

--- a/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeNode.kt
+++ b/ij-plugin/src/main/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeNode.kt
@@ -83,7 +83,7 @@ fun alternativesOf(
 
 private fun tokenNode(token: TokenSpec): GrammarTreeNode {
     val secondary = if (token.ignored) "${token.pattern}  [ignored]" else token.pattern
-    return GrammarTreeNode(token.name, secondary, sourceFile = token.sourceFile.orNullSource(), sourceLine = token.sourceLine)
+    return GrammarTreeNode(token.name, secondary, sourceFile = token.source?.file, sourceLine = token.source?.line)
 }
 
 private fun alternativeRow(
@@ -99,11 +99,7 @@ private fun alternativeRow(
         production.name ?: "(unnamed)",
         rhsText,
         children = nonterminalRefs,
-        sourceFile = production.sourceFile.orNullSource(),
-        sourceLine = production.sourceLine,
+        sourceFile = production.source?.file,
+        sourceLine = production.source?.line,
     )
 }
-
-/** A blank export-side `sourceFile` marks a row with no source of its own (see [GrammarTreeNode]'s
- *  doc) -- normalized to `null` here so a UI can tell "no source" apart from "source is /path". */
-private fun String?.orNullSource(): String? = this?.takeIf { it.isNotBlank() }

--- a/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeTest.kt
+++ b/ij-plugin/src/test/kotlin/com/halotukozak/alpaca/plugin/toolwindow/GrammarTreeTest.kt
@@ -3,6 +3,7 @@ package com.halotukozak.alpaca.plugin.toolwindow
 import com.halotukozak.alpaca.plugin.grammar.ParserGrammar
 import com.halotukozak.alpaca.plugin.grammar.ProductionSpec
 import com.halotukozak.alpaca.plugin.grammar.ResolvedGrammar
+import com.halotukozak.alpaca.plugin.grammar.SourceLocation
 import com.halotukozak.alpaca.plugin.grammar.SymbolSpec
 import com.halotukozak.alpaca.plugin.grammar.TokenSpec
 import org.junit.Assert.assertEquals
@@ -127,8 +128,8 @@ class GrammarTreeTest {
 
     @Test
     fun `carries the source location for tokens and production alternatives`() {
-        val token = intToken.copy(sourceFile = "/x/Lexer.scala", sourceLine = 4)
-        val production = literalProduction.copy(sourceFile = "/x/Parser.scala", sourceLine = 9)
+        val token = intToken.copy(source = SourceLocation(file = "/x/Lexer.scala", line = 4))
+        val production = literalProduction.copy(source = SourceLocation(file = "/x/Parser.scala", line = 9))
         val resolved = ResolvedGrammar("Lexer", listOf(token), ParserGrammar("Parser", listOf(production)))
 
         val tokenNode = buildGrammarTree(resolved).children[0].children.single()
@@ -145,8 +146,8 @@ class GrammarTreeTest {
     }
 
     @Test
-    fun `a blank exported source file means no source, not an empty path`() {
-        val synthetic = literalProduction.copy(sourceFile = "", sourceLine = 0)
+    fun `no exported source means no source, not a row missing it by omission`() {
+        val synthetic = literalProduction.copy(source = null)
         val resolved = ResolvedGrammar("Lexer", emptyList(), ParserGrammar("Parser", listOf(synthetic)))
 
         val node =


### PR DESCRIPTION
## Summary
- Main on CI is red: after #583 merged, the `IntelliJ Plugin` workflow's `test` job fails 67/136 tests with `kotlinx.serialization.json.JsonDecodingException`.
- #583 (Scala side) exports a rule's source location nested as `"source": {"line": ..., "file": ...}`. #582 (Kotlin side, merged just before it) had instead added flat `sourceFile`/`sourceLine` fields to `TokenSpec`/`ProductionSpec`, anticipating a different shape. Neither PR's own CI caught the mismatch: #583 only touched Scala code, so the plugin's `changes` path filter skipped `test`/`verify` on that PR entirely (by design, to avoid a ~15m plugin build on every library-only PR) — the mismatch only surfaced on the unconditional post-merge run on `main`.
- Since the plugin is still pre-1.0 and has never shipped against the old flat shape, this fixes it by making `TokenSpec`/`ProductionSpec` mirror the export directly (`source: SourceLocation?`) instead of translating between two shapes.

## Changes
- `GrammarFile.kt`: replace `sourceFile`/`sourceLine` with a nested `source: SourceLocation?` matching the export's actual JSON.
- `GrammarTreeNode.kt`: read `token.source?.file`/`production.source?.file` (drops the now-dead blank-string-means-no-source normalization, since the export always uses `null`, never a blank string).
- `GrammarTreeTest.kt`: updated to construct `SourceLocation`; the "blank exported source" test is replaced with a "no source" (`null`) case, since blank can no longer occur.

## Test plan
- [x] `./gradlew ktlintCheck test` (with a real, non-cached rebuild) — all green
- [x] `./gradlew verifyPlugin` — Compatible against all 5 target IDEs
- [x] `./gradlew buildPlugin` — succeeds