### PR TITLE
Let the IJ plugin publish workflow bump the version itself

### DIFF
--- a/.github/workflows/ij-plugin-publish.yml
+++ b/.github/workflows/ij-plugin-publish.yml
@@ -2,21 +2,27 @@ name: Publish IntelliJ Plugin
 
 # Manual-only: the repo's `v*` tags already drive the Scala library's Sonatype publish
 # and any tag drives the docs deploy, so the plugin gets its own explicitly-triggered
-# workflow instead of a tag pattern. Release flow:
-#   1. bump `version` in ij-plugin/gradle.properties
-#   2. run `./gradlew patchChangelog` in ij-plugin/ (moves [Unreleased] -> [x.y.z])
-#   3. commit + merge to main
-#   4. run this workflow from the Actions tab
+# workflow instead of a tag pattern. Release flow, entirely from the Actions tab:
+#   1. Run this workflow with the "version" input set to the new version (e.g. 0.2.0).
+#   2. The workflow bumps ij-plugin/gradle.properties, runs `patchChangelog`
+#      (moves [Unreleased] -> [x.y.z]), commits that to main, then builds, signs,
+#      verifies and publishes the plugin built from that commit.
+# Leave "version" empty to re-run a publish for whatever version is already committed
+# (e.g. to retry a failed upload) without creating a new bump commit.
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: 'New version to release (e.g. 0.2.0). Leave empty to publish the version already in gradle.properties.'
+        type: string
+        required: false
       dry_run:
         description: 'Build, sign and verify but do NOT upload to the Marketplace'
         type: boolean
         default: false
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ij-plugin-publish
@@ -34,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: main
       - name: Set up JDK
         uses: actions/setup-java@v6
         with:
@@ -42,8 +50,22 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
         with:
-          build-root-directory: ij-plugin
           cache-read-only: true
+
+      - name: Bump version and patch changelog
+        if: ${{ inputs.version != '' }}
+        run: |
+          sed -i "s/^version = .*/version = ${{ inputs.version }}/" gradle.properties
+          ./gradlew patchChangelog
+
+      - name: Commit version bump
+        if: ${{ inputs.version != '' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add gradle.properties CHANGELOG.md
+          git commit -m "Release IntelliJ plugin v${{ inputs.version }}"
+          git push origin HEAD:main
 
       - name: Verify plugin
         run: ./gradlew verifyPlugin

--- a/.github/workflows/ij-plugin-publish.yml
+++ b/.github/workflows/ij-plugin-publish.yml
@@ -3,19 +3,25 @@ name: Publish IntelliJ Plugin
 # Manual-only: the repo's `v*` tags already drive the Scala library's Sonatype publish
 # and any tag drives the docs deploy, so the plugin gets its own explicitly-triggered
 # workflow instead of a tag pattern. Release flow, entirely from the Actions tab:
-#   1. Run this workflow with the "version" input set to the new version (e.g. 0.2.0).
-#   2. The workflow bumps ij-plugin/gradle.properties, runs `patchChangelog`
-#      (moves [Unreleased] -> [x.y.z]), commits that to main, then builds, signs,
+#   1. Run this workflow, picking "bump" (patch/minor/major).
+#   2. The workflow computes the next x.y.z from the current
+#      ij-plugin/gradle.properties, bumps it, runs `patchChangelog` (moves
+#      [Unreleased] -> [x.y.z]), commits that to main, then builds, signs,
 #      verifies and publishes the plugin built from that commit.
-# Leave "version" empty to re-run a publish for whatever version is already committed
+# Pick "none" to re-run a publish for whatever version is already committed
 # (e.g. to retry a failed upload) without creating a new bump commit.
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'New version to release (e.g. 0.2.0). Leave empty to publish the version already in gradle.properties.'
-        type: string
-        required: false
+      bump:
+        description: 'Version part to bump (none = republish the current version as-is)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - none
+        default: patch
       dry_run:
         description: 'Build, sign and verify but do NOT upload to the Marketplace'
         type: boolean
@@ -52,19 +58,32 @@ jobs:
         with:
           cache-read-only: true
 
-      - name: Bump version and patch changelog
-        if: ${{ inputs.version != '' }}
+      - name: Compute next version
+        if: ${{ inputs.bump != 'none' }}
+        id: next_version
         run: |
-          sed -i "s/^version = .*/version = ${{ inputs.version }}/" gradle.properties
+          current="$(grep -oP '^version = \K.*' gradle.properties)"
+          IFS='.' read -r major minor patch <<< "$current"
+          case "${{ inputs.bump }}" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+          echo "version=$major.$minor.$patch" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version and patch changelog
+        if: ${{ inputs.bump != 'none' }}
+        run: |
+          sed -i "s/^version = .*/version = ${{ steps.next_version.outputs.version }}/" gradle.properties
           ./gradlew patchChangelog
 
       - name: Commit version bump
-        if: ${{ inputs.version != '' }}
+        if: ${{ inputs.bump != 'none' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add gradle.properties CHANGELOG.md
-          git commit -m "Release IntelliJ plugin v${{ inputs.version }}"
+          git commit -m "Release IntelliJ plugin v${{ steps.next_version.outputs.version }}"
           git push origin HEAD:main
 
       - name: Verify plugin


### PR DESCRIPTION
## Summary
- Adds a `bump` workflow_dispatch input (dropdown: `patch` / `minor` / `major` / `none`) to `ij-plugin-publish.yml`: the workflow reads the current version from `ij-plugin/gradle.properties`, computes the next `x.y.z`, bumps it, runs `patchChangelog`, and commits/pushes that to `main` before building/signing/publishing — so a release is one manual click in the Actions tab instead of a local commit + push first.
- `none` republishes whatever version is already committed (useful to retry a failed upload without creating a new bump commit) — which is what happened for `0.1.0` in run [34334218945](https://github.com/halotukozak-com/alpaca/actions/runs/34334218945): that upload failed only because the version was already published on the Marketplace, not because of a real bug.
- Drops the `build-root-directory` input to `gradle/actions/setup-gradle`, which isn't a recognized input on the pinned action version (was producing a harmless but noisy warning annotation).
- Sets `permissions: contents: write` so the workflow's bump commit can be pushed.

## Test plan
- [ ] Run "Publish IntelliJ Plugin" from the Actions tab with `bump: minor` and confirm it commits the version bump and publishes successfully.
- [ ] Run it again with `bump: none` and `dry_run: true` to confirm the no-bump path still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)