### PR TITLE
Route IJ plugin version bump through a PR (main is protected)

### DIFF
--- a/.github/workflows/ij-plugin-publish.yml
+++ b/.github/workflows/ij-plugin-publish.yml
@@ -6,10 +6,14 @@ name: Publish IntelliJ Plugin
 #   1. Run this workflow, picking "bump" (patch/minor/major).
 #   2. The workflow computes the next x.y.z from the current
 #      ij-plugin/gradle.properties, bumps it, runs `patchChangelog` (moves
-#      [Unreleased] -> [x.y.z]), commits that to main, then builds, signs,
-#      verifies and publishes the plugin built from that commit.
+#      [Unreleased] -> [x.y.z]), and opens a PR with that change against main.
+#      `main` is protected (required status checks, no direct pushes), so the
+#      job enables auto-merge on that PR and waits for it to actually merge
+#      before continuing.
+#   3. Once the bump is on main, the workflow builds, signs, verifies and
+#      publishes the plugin built from that commit.
 # Pick "none" to re-run a publish for whatever version is already committed
-# (e.g. to retry a failed upload) without creating a new bump commit.
+# (e.g. to retry a failed upload) without creating a new bump PR.
 on:
   workflow_dispatch:
     inputs:
@@ -29,6 +33,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: ij-plugin-publish
@@ -37,6 +42,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     # Point this at a GitHub Environment holding the four secrets below if you want
     # required-reviewer protection on publishes. The secrets can also live at repo level.
     # environment: marketplace
@@ -77,14 +83,54 @@ jobs:
           sed -i "s/^version = .*/version = ${{ steps.next_version.outputs.version }}/" gradle.properties
           ./gradlew patchChangelog
 
-      - name: Commit version bump
+      - name: Open version bump PR
         if: ${{ inputs.bump != 'none' }}
+        id: bump_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          branch="release/plugin-v${{ steps.next_version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
           git add gradle.properties CHANGELOG.md
           git commit -m "Release IntelliJ plugin v${{ steps.next_version.outputs.version }}"
-          git push origin HEAD:main
+          git push origin "$branch"
+          pr_url=$(gh pr create \
+            --title "Release IntelliJ plugin v${{ steps.next_version.outputs.version }}" \
+            --body "Automated version bump, opened by the Publish IntelliJ Plugin workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --base main --head "$branch")
+          gh pr merge "$pr_url" --merge --auto
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      # main requires status checks and forbids direct pushes, so the bump above went
+      # through a PR instead. Block here until that PR actually merges, then resync
+      # the checkout to the merged commit before building/publishing from it.
+      - name: Wait for version bump PR to merge
+        if: ${{ inputs.bump != 'none' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_url="${{ steps.bump_pr.outputs.pr_url }}"
+          for i in $(seq 1 120); do
+            state=$(gh pr view "$pr_url" --json state -q .state)
+            if [ "$state" = "MERGED" ]; then
+              exit 0
+            fi
+            if [ "$state" = "CLOSED" ]; then
+              echo "::error::$pr_url was closed without merging"
+              exit 1
+            fi
+            sleep 30
+          done
+          echo "::error::Timed out waiting for $pr_url to merge"
+          exit 1
+
+      - name: Sync checkout to merged main
+        if: ${{ inputs.bump != 'none' }}
+        run: |
+          git fetch origin main
+          git checkout -B main origin/main
 
       - name: Verify plugin
         run: ./gradlew verifyPlugin


### PR DESCRIPTION
## Summary
Follow-up to #586: the first run of the reworked workflow ([34336694556](https://github.com/halotukozak-com/alpaca/actions/runs/34336694556)) failed at the "Commit version bump" step because `main` is a protected branch (required status checks: Scalafmt, Test (jvm/native/js), Docs, Plugin CI; no direct pushes).

- The version-bump step now pushes to a `release/plugin-vX.Y.Z` branch, opens a PR against `main`, enables auto-merge, and the job blocks until that PR actually merges before continuing to build/verify/sign/publish.
- None of the required checks are path-filtered, so they always run even for a bump-only PR touching just `gradle.properties`/`CHANGELOG.md`.

## Test plan
- [ ] Run "Publish IntelliJ Plugin" with `bump: minor`, confirm the bump PR opens, auto-merges once CI is green, and the plugin then publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)